### PR TITLE
chore: add open source community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug Report
+about: Report a reproducible bug in Stellar SolarGrid
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include any error messages or stack traces.
+
+## Screenshots / Logs
+
+If applicable, paste logs or attach screenshots here.
+
+## Environment
+
+| Field | Value |
+|-------|-------|
+| Component | <!-- contracts / frontend / backend --> |
+| OS | <!-- e.g. Ubuntu 22.04, macOS 14 --> |
+| Node.js version | <!-- `node -v` --> |
+| Rust version | <!-- `rustc --version` --> |
+| Stellar CLI version | <!-- `stellar --version` --> |
+| Browser (if frontend) | <!-- e.g. Chrome 124 --> |
+| Network | <!-- testnet / mainnet --> |
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+What problem does this feature solve? Who is affected?
+
+## Proposed Solution
+
+Describe the feature you'd like. Be as specific as possible.
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about and why you ruled them out.
+
+## Affected Component(s)
+
+- [ ] Smart contracts (Soroban / Rust)
+- [ ] Frontend (React / TypeScript)
+- [ ] Backend / IoT bridge (Node.js)
+- [ ] Documentation
+- [ ] Other: <!-- describe -->
+
+## Additional Context
+
+Mockups, diagrams, links to related issues, or any other context that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Related Issue
+
+Closes #<!-- issue number -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code cleanup
+- [ ] Documentation update
+- [ ] Dependency update
+- [ ] Other: <!-- describe -->
+
+## Changes Made
+
+<!-- Bullet-point list of the key changes. Focus on the *why*, not just the *what*. -->
+
+-
+-
+
+## How to Test
+
+<!-- Steps a reviewer can follow to verify the change works correctly. -->
+
+1.
+2.
+
+## Checklist
+
+- [ ] Code builds without errors (`cargo build` / `npm run build`)
+- [ ] No TypeScript errors (`tsc --noEmit`)
+- [ ] Rust code is formatted (`cargo fmt`) and lint-clean (`cargo clippy -- -D warnings`)
+- [ ] No unintended breaking changes to existing functionality
+- [ ] PR targets the `main` branch and is rebased on the latest upstream
+
+## Screenshots (if applicable)
+
+<!-- Delete this section if not relevant. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in Stellar SolarGrid a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub issues, pull requests, discussions, and any other official communication channels — and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter.
+
+## Enforcement Guidelines
+
+Maintainers will follow these guidelines when determining consequences:
+
+**1. Correction** — A private written warning with clarity around the nature of the violation and an explanation of why the behavior was inappropriate.
+
+**2. Warning** — A warning with consequences for continued behavior. No interaction with the people involved for a specified period.
+
+**3. Temporary Ban** — A temporary ban from any sort of interaction or public communication with the community.
+
+**4. Permanent Ban** — A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to Stellar SolarGrid
+
+Thanks for your interest in contributing! This guide covers everything you need to get up and running.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Development Setup](#development-setup)
+- [Coding Standards](#coding-standards)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+
+---
+
+## Getting Started
+
+1. Fork the repository and clone your fork:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/Stellar-Solar-Grid.git
+   cd Stellar-Solar-Grid
+   ```
+
+2. Add the upstream remote:
+   ```bash
+   git remote add upstream https://github.com/ORIGINAL_OWNER/Stellar-Solar-Grid.git
+   ```
+
+3. Create a feature branch off `main`:
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+
+---
+
+## Project Structure
+
+```
+Stellar-Solar-Grid/
+├── contracts/     # Soroban smart contracts (Rust)
+├── frontend/      # React + TypeScript dashboards (Vite)
+└── backend/       # Node.js API + IoT MQTT bridge (Express + tsx)
+```
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+| Tool | Version |
+|------|---------|
+| Node.js | >= 18 |
+| Rust | stable (via [rustup](https://rustup.rs/)) |
+| Stellar CLI | latest |
+| Freighter Wallet | browser extension |
+
+Add the WASM target once after installing Rust:
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+### Smart Contracts
+
+```bash
+cd contracts
+cargo build --target wasm32-unknown-unknown --release
+```
+
+Deploy to testnet:
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/solar_grid.wasm \
+  --network testnet
+```
+
+### Frontend
+
+```bash
+cd frontend
+cp .env.example .env        # fill in your contract ID and network
+npm install
+npm run dev
+```
+
+### Backend
+
+```bash
+cd backend
+cp .env.example .env        # fill in your Stellar keys and MQTT config
+npm install
+npm run dev
+```
+
+---
+
+## Coding Standards
+
+### TypeScript (frontend & backend)
+
+- Use TypeScript strict mode — no `any` unless absolutely necessary.
+- Prefer `const` over `let`; avoid `var`.
+- Name files in `kebab-case`, components in `PascalCase`.
+- Keep functions small and single-purpose.
+- Run `tsc --noEmit` before committing to catch type errors.
+
+### Rust (contracts)
+
+- Follow standard Rust formatting: `cargo fmt` before every commit.
+- Run `cargo clippy -- -D warnings` and fix all warnings.
+- Document public functions with `///` doc comments.
+- Avoid `unwrap()` in contract code — handle errors explicitly.
+
+### General
+
+- No commented-out dead code in PRs.
+- Keep commits atomic and write meaningful commit messages using [Conventional Commits](https://www.conventionalcommits.org/):
+  ```
+  feat: add weekly payment plan support
+  fix: correct meter access check logic
+  docs: update contract deployment steps
+  ```
+
+---
+
+## Submitting a Pull Request
+
+1. Sync with upstream before opening a PR:
+   ```bash
+   git fetch upstream
+   git rebase upstream/main
+   ```
+
+2. Make sure the project builds cleanly:
+   ```bash
+   # Contracts
+   cargo build --target wasm32-unknown-unknown --release
+
+   # Frontend
+   cd frontend && npm run build
+
+   # Backend
+   cd backend && npm run build
+   ```
+
+3. Push your branch and open a PR against `main`.
+
+4. Fill out the pull request template completely.
+
+5. A maintainer will review your PR. Please respond to feedback promptly and keep the branch up to date.
+
+### PR Checklist
+
+- [ ] Code builds without errors or warnings
+- [ ] Existing functionality is not broken
+- [ ] New logic is reasonably self-documenting or commented
+- [ ] PR description explains the *why*, not just the *what*
+
+---
+
+For questions, open a [Discussion](../../discussions) or drop a comment on the relevant issue.


### PR DESCRIPTION
This PR closes #5 
## Summary

This PR adds the standard open source community files to make the repo contributor-friendly.

## Changes

- **CONTRIBUTING.md** — full setup guide for all three components (Soroban contracts, React frontend, Node.js backend), coding standards for TypeScript and Rust, and PR workflow
- **.github/ISSUE_TEMPLATE/bug_report.md** — structured bug report template with environment table covering Node, Rust, Stellar CLI, browser, and network
- **.github/ISSUE_TEMPLATE/feature_request.md** — feature proposal template with component checkboxes matching the actual stack
- **.github/PULL_REQUEST_TEMPLATE.md** — PR template with type-of-change, test steps, and a build/lint checklist
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 with enforcement guidelines

## Why

Without these files, new contributors have no clear path to set up the project, report issues, or submit PRs consistently. This brings the repo up to standard open source expectations.
