### PR TITLE
fix: show friendly message when Freighter transaction is rejected

### DIFF
--- a/frontend/src/app/pay/page.tsx
+++ b/frontend/src/app/pay/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "@/components/Navbar";
+import { useWalletStore } from "@/store/walletStore";
+import { makePayment } from "@/services/meterService";
+import { parseWalletError } from "@/lib/errors";
+
+type Plan = "Daily" | "Weekly" | "Usage";
+type Status = "idle" | "loading" | "success" | "error" | "cancelled";
+
+const PLANS: { value: Plan; label: string; desc: string }[] = [
+  { value: "Daily", label: "Daily", desc: "Billed every 24 hours" },
+  { value: "Weekly", label: "Weekly", desc: "Billed every 7 days" },
+  { value: "Usage", label: "Usage-Based", desc: "Pay per kWh consumed" },
+];
+
+export default function PayPage() {
+  const { address, connect } = useWalletStore();
+
+  const [meterId, setMeterId] = useState("");
+  const [amount, setAmount] = useState("");
+  const [plan, setPlan] = useState<Plan>("Daily");
+  const [status, setStatus] = useState<Status>("idle");
+  const [message, setMessage] = useState("");
+  const [txHash, setTxHash] = useState("");
+
+  const EXPLORER_BASE = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE?.includes("Test")
+    ? "https://stellar.expert/explorer/testnet/tx"
+    : "https://stellar.expert/explorer/public/tx";
+
+  async function handlePay(e: React.FormEvent) {
+    e.preventDefault();
+    if (!address) return;
+
+    const amountNum = parseFloat(amount);
+    if (!meterId.trim() || isNaN(amountNum) || amountNum <= 0) return;
+
+    setStatus("loading");
+    setMessage("");
+    setTxHash("");
+
+    try {
+      const hash = await makePayment(address, meterId.trim(), amountNum, plan);
+      setTxHash(hash);
+      setStatus("success");
+      setMessage("Payment successful!");
+    } catch (err: unknown) {
+      const friendly = parseWalletError(err);
+      if (friendly === "Transaction cancelled by user.") {
+        setStatus("cancelled");
+      } else {
+        setStatus("error");
+      }
+      setMessage(friendly);
+    }
+  }
+
+  function reset() {
+    setStatus("idle");
+    setMessage("");
+    setTxHash("");
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen flex items-start justify-center px-4 py-16">
+        <div className="w-full max-w-md">
+          <h1 className="text-3xl font-bold text-solar-yellow mb-2">Make a Payment</h1>
+          <p className="text-gray-400 text-sm mb-8">
+            Top up your meter balance on the Stellar blockchain.
+          </p>
+
+          {!address ? (
+            <div className="rounded-xl border border-white/10 bg-solar-accent p-8 text-center">
+              <p className="text-gray-400 mb-4">Connect your wallet to make a payment.</p>
+              <button
+                onClick={connect}
+                className="rounded-lg bg-solar-yellow px-6 py-2.5 font-semibold text-solar-dark hover:opacity-90 transition"
+              >
+                Connect Wallet
+              </button>
+            </div>
+          ) : (
+            <form
+              onSubmit={handlePay}
+              className="rounded-xl border border-white/10 bg-solar-accent p-6 space-y-5"
+            >
+              {/* Meter ID */}
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  Meter ID
+                </label>
+                <input
+                  type="text"
+                  value={meterId}
+                  onChange={(e) => { setMeterId(e.target.value); reset(); }}
+                  placeholder="e.g. METER1"
+                  required
+                  className="w-full rounded-lg border border-white/10 bg-solar-dark px-4 py-2.5 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+                />
+              </div>
+
+              {/* Amount */}
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  Amount (XLM)
+                </label>
+                <input
+                  type="number"
+                  value={amount}
+                  onChange={(e) => { setAmount(e.target.value); reset(); }}
+                  placeholder="0.00"
+                  min="0.0000001"
+                  step="any"
+                  required
+                  className="w-full rounded-lg border border-white/10 bg-solar-dark px-4 py-2.5 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+                />
+              </div>
+
+              {/* Plan */}
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">
+                  Billing Plan
+                </label>
+                <div className="grid grid-cols-3 gap-2">
+                  {PLANS.map((p) => (
+                    <button
+                      key={p.value}
+                      type="button"
+                      onClick={() => setPlan(p.value)}
+                      className={`rounded-lg border px-3 py-2.5 text-left transition ${
+                        plan === p.value
+                          ? "border-solar-yellow bg-solar-yellow/10 text-solar-yellow"
+                          : "border-white/10 text-gray-400 hover:border-white/30"
+                      }`}
+                    >
+                      <div className="text-xs font-semibold">{p.label}</div>
+                      <div className="text-[10px] opacity-70 mt-0.5">{p.desc}</div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Feedback */}
+              {status === "cancelled" && (
+                <div className="flex items-center gap-2 rounded-lg border border-yellow-500/40 bg-yellow-900/20 px-4 py-3 text-sm text-yellow-300">
+                  <span>⚠️</span>
+                  <span>{message}</span>
+                </div>
+              )}
+              {status === "error" && (
+                <div className="flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-900/20 px-4 py-3 text-sm text-red-400">
+                  <span>✕</span>
+                  <span>{message}</span>
+                </div>
+              )}
+              {status === "success" && (
+                <div className="rounded-lg border border-green-500/40 bg-green-900/20 px-4 py-3 text-sm text-green-400">
+                  <div className="font-semibold mb-1">✓ {message}</div>
+                  {txHash && (
+                    <a
+                      href={`${EXPLORER_BASE}/${txHash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 underline underline-offset-2 font-mono text-xs hover:text-blue-300 transition"
+                    >
+                      {txHash.slice(0, 10)}…{txHash.slice(-8)} ↗
+                    </a>
+                  )}
+                </div>
+              )}
+
+              {/* Submit */}
+              <button
+                type="submit"
+                disabled={status === "loading"}
+                className="w-full rounded-lg bg-solar-yellow py-3 font-semibold text-solar-dark hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition"
+              >
+                {status === "loading" ? "Waiting for wallet…" : "Pay Now"}
+              </button>
+            </form>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -18,6 +18,9 @@ export default function Navbar() {
         <Link href="/dashboard/user" className="text-sm text-gray-300 hover:text-white transition">
           My Meter
         </Link>
+        <Link href="/pay" className="text-sm text-gray-300 hover:text-white transition">
+          Pay
+        </Link>
         <Link
           href="/dashboard/provider"
           className="text-sm text-gray-300 hover:text-white transition"

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -1,0 +1,85 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { useWalletStore } from "@/store/walletStore";
+
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL!;
+const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID!;
+const NETWORK_PASSPHRASE = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE!;
+
+const server = new StellarSdk.SorobanRpc.Server(RPC_URL);
+
+export interface MeterData {
+  owner: string;
+  active: boolean;
+  balance: bigint;
+  units_used: bigint;
+  plan: string;
+  last_payment: bigint;
+}
+
+export async function fetchMeter(meterId: string): Promise<MeterData> {
+  const contract = new StellarSdk.Contract(CONTRACT_ID);
+  // Use a throwaway keypair for read-only simulation
+  const keypair = StellarSdk.Keypair.random();
+  const account = new StellarSdk.Account(keypair.publicKey(), "0");
+
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "get_meter",
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (StellarSdk.SorobanRpc.Api.isSimulationError(sim)) {
+    throw new Error(sim.error);
+  }
+  const retval = (sim as StellarSdk.SorobanRpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+  if (!retval) throw new Error("No result from contract");
+  return StellarSdk.scValToNative(retval) as MeterData;
+}
+
+/**
+ * Build, simulate, sign (via connected wallet), and submit a contract call.
+ * Throws raw errors — callers should wrap with parseWalletError().
+ */
+export async function contractInvoke(
+  sourceAddress: string,
+  method: string,
+  args: StellarSdk.xdr.ScVal[]
+): Promise<string> {
+  const contract = new StellarSdk.Contract(CONTRACT_ID);
+  const account = await server.getAccount(sourceAddress);
+
+  let tx = new StellarSdk.TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (StellarSdk.SorobanRpc.Api.isSimulationError(sim)) {
+    throw new Error(sim.error);
+  }
+
+  tx = StellarSdk.SorobanRpc.assembleTransaction(tx, sim).build();
+
+  // Sign via wallet (Freighter rejection throws here)
+  const { signTransaction } = useWalletStore.getState();
+  const signedXdr = await signTransaction(tx.toXDR());
+
+  const signedTx = StellarSdk.TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+  const result = await server.sendTransaction(signedTx);
+
+  if (result.status === "ERROR") {
+    throw new Error(`Transaction failed: ${result.errorResult}`);
+  }
+  return result.hash;
+}

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,0 +1,65 @@
+/**
+ * Normalises errors thrown by Freighter / stellar-wallets-kit / Soroban RPC
+ * into a human-readable string.
+ */
+
+// Known Freighter rejection signals
+const REJECTION_PATTERNS = [
+  "user declined",
+  "user rejected",
+  "transaction was rejected",
+  "rejected by user",
+  "cancelled by user",
+  "user cancel",
+  "request was rejected",
+  "-4",          // Freighter numeric code for user rejection
+  "4001",        // EIP-1193 style rejection code used by some wallets
+];
+
+export function parseWalletError(err: unknown): string {
+  const raw = normaliseToString(err);
+  const lower = raw.toLowerCase();
+
+  if (REJECTION_PATTERNS.some((p) => lower.includes(p))) {
+    return "Transaction cancelled by user.";
+  }
+
+  if (lower.includes("network") || lower.includes("fetch")) {
+    return "Network error — please check your connection and try again.";
+  }
+
+  if (lower.includes("insufficient") || lower.includes("balance")) {
+    return "Insufficient balance to complete this transaction.";
+  }
+
+  if (lower.includes("not found") || lower.includes("meter")) {
+    return "Meter not found. Please check the meter ID and try again.";
+  }
+
+  if (lower.includes("timeout")) {
+    return "Transaction timed out. Please try again.";
+  }
+
+  // Fall back to a cleaned-up version of the raw message (never a raw object)
+  return raw.length > 0 && raw.length < 200
+    ? raw
+    : "Something went wrong. Please try again.";
+}
+
+function normaliseToString(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    // Freighter sometimes throws { code: -4, message: "..." }
+    const e = err as Record<string, unknown>;
+    if (typeof e.message === "string") return e.message;
+    if (typeof e.error === "string") return e.error;
+    if (typeof e.code === "number") return `Error code: ${e.code}`;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return "Unknown error";
+    }
+  }
+  return "Unknown error";
+}

--- a/frontend/src/store/walletStore.ts
+++ b/frontend/src/store/walletStore.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { create } from "zustand";
+import { StellarWalletsKit, WalletNetwork, FREIGHTER_ID } from "@creit.tech/stellar-wallets-kit";
+
+interface WalletState {
+  address: string | null;
+  kit: StellarWalletsKit | null;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  signTransaction: (xdr: string) => Promise<string>;
+}
+
+function buildKit(): StellarWalletsKit {
+  return new StellarWalletsKit({
+    network:
+      process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE?.includes("Test")
+        ? WalletNetwork.TESTNET
+        : WalletNetwork.PUBLIC,
+    selectedWalletId: FREIGHTER_ID,
+  });
+}
+
+export const useWalletStore = create<WalletState>((set, get) => ({
+  address: null,
+  kit: null,
+
+  connect: async () => {
+    const kit = buildKit();
+    await kit.openModal({
+      onWalletSelected: async (option) => {
+        kit.setWallet(option.id);
+        const { address } = await kit.getAddress();
+        set({ address, kit });
+      },
+    });
+  },
+
+  disconnect: () => set({ address: null, kit: null }),
+
+  signTransaction: async (xdr: string) => {
+    const { kit, address } = get();
+    if (!kit || !address) throw new Error("Wallet not connected");
+    const { signedTxXdr } = await kit.signTransaction(xdr, {
+      address,
+      networkPassphrase: process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE!,
+    });
+    return signedTxXdr;
+  },
+}));


### PR DESCRIPTION
Fixes #24 

Problem
When a user rejected a transaction in Freighter, the UI displayed a raw error object instead of a human-readable message.

Root Cause
The catch block in the Pay page was rendering the raw error directly without normalising it. Freighter throws objects like { code: -4, message: "User declined" } which React renders as [object Object].

Fix
errors.ts
 — new parseWalletError(err: unknown): string utility that:

Detects Freighter rejection signals (code -4, "user declined", "user rejected", etc.)
Returns "Transaction cancelled by user." for rejections
Maps other known patterns (network errors, insufficient balance, meter not found) to friendly messages
Never renders a raw object — always returns a clean string
page.tsx
 — Pay page wraps makePayment with parseWalletError and distinguishes between:

cancelled → yellow warning banner (⚠️ Transaction cancelled by user.)
error → red error banner with the friendly message
success → green confirmation with explorer link
walletStore.ts
 + 
contract.ts
 — implemented wallet connection and contract invocation via StellarWalletsKit.

Before / After
Before	After
[object Object] or raw JSON blob	⚠️ Transaction cancelled by user.
Testing
Go to /pay, connect Freighter
Fill in meter ID and amount, click Pay
Reject in Freighter popup
Confirm yellow banner shows Transaction cancelled by user.