### PR TITLE
feat: implement issues #30 #31 #32 #33

### DIFF
--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -28,6 +28,18 @@ meterRouter.get("/:id/access", async (req, res) => {
   }
 });
 
+/** GET /api/meters/owner/:address — list all meters for an owner (#32) */
+meterRouter.get("/owner/:address", async (req, res) => {
+  try {
+    const result = await contractQuery("get_meters_by_owner", [
+      StellarSdk.nativeToScVal(req.params.address, { type: "address" }),
+    ]);
+    res.json({ meters: StellarSdk.scValToNative(result) });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 /** POST /api/meters — register a new meter (admin only) */
 meterRouter.post("/", async (req, res) => {
   const { meter_id, owner } = req.body as { meter_id: string; owner: string };


### PR DESCRIPTION
## Summary

Closes #30
Closes #31
Closes #32
Closes #33

### #30 fix(backend): poll for tx confirmation in adminInvoke
- Poll `server.getTransaction` until `SUCCESS` or `FAILED`
- Throw on `FAILED` status with error message
- Configurable timeout via `TX_TIMEOUT_MS` env var (default 30s)

### #31 feat(backend): SMS payment webhook for offline users
- `POST /api/webhooks/sms-payment` endpoint
- HMAC-SHA256 signature verification via `X-Webhook-Signature` header
- Parses `meter_id` and `amount_xlm`, converts to stroops, calls `make_payment` on-chain

### #32 feat(contract): multi-meter support per owner
- Added `OwnerMeters(Address)` variant to `DataKey`
- `register_meter` appends meter ID to owner's persistent `Vec<Symbol>`
- New `get_meters_by_owner(owner: Address) -> Vec<Symbol>` contract query
- New `GET /api/meters/owner/:address` REST endpoint

### #33 feat(frontend): provider dashboard with meter registration form
- New page at `/dashboard/provider`
- Client-side Stellar address validation (G + 55 base32 chars)
- Calls `POST /api/meters`, shows tx hash with Stellar Explorer link on success