### PR TITLE
fix(contract): prevent update_usage overflow on large cost values

### DIFF
--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -281,7 +281,7 @@ impl SolarGridContract {
         let key = DataKey::Meter(meter_id.clone());
         let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
         meter.units_used += units;
-        meter.balance -= cost;
+        meter.balance = meter.balance.saturating_sub(cost);
         let deactivated = if meter.balance <= 0 {
             meter.balance = 0;
             meter.active = false;
@@ -455,6 +455,24 @@ mod tests {
         let meter = client.get_meter(&meter_id);
         assert_eq!(meter.balance, 0);
         assert_eq!(meter.units_used, 110);
+        assert!(!meter.active);
+    }
+
+    /// update_usage with a huge cost should clamp balance to zero without panic.
+    #[test]
+    fn test_update_usage_huge_cost_clamps_to_zero() {
+        let (env, client, _admin) = setup();
+
+        let user = Address::generate(&env);
+        let meter_id = symbol_short!("METER9");
+
+        allowlist_and_register(&client, &meter_id, &user);
+        client.make_payment(&meter_id, &user, &100_i128, &PaymentPlan::UsageBased);
+
+        client.update_usage(&meter_id, &1_u64, &i128::MAX);
+        let meter = client.get_meter(&meter_id);
+        assert_eq!(meter.balance, 0);
+        assert_eq!(meter.units_used, 1);
         assert!(!meter.active);
     }
 


### PR DESCRIPTION
## Summary
- replace direct subtraction in `update_usage` with `saturating_sub` to prevent overflow on extreme `cost` values
- preserve existing clamp-to-zero and deactivation behavior when balance is exhausted
- add a regression test for `cost = i128::MAX` to ensure the meter ends at zero balance and becomes inactive

## Test plan
- [x] review contract diff for `update_usage` arithmetic safety
- [x] add regression test case for large cost input
- [ ] run `cargo test -p solar_grid` end-to-end (currently blocked by pre-existing duplicate allowlist methods and unrelated existing test compile issues in this worktree)

Closes Dev-AdeTutu/Stellar-Solar-Grid#17
