### PR TITLE
fix(contract): use checked_sub to prevent balance underflow in update…

### DIFF
--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -273,9 +273,7 @@ impl SolarGridContract {
         let key = DataKey::Meter(meter_id.clone());
         let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
         meter.units_used += units;
-        // Clamp to 0: saturating_sub on i128 would bottom out at i128::MIN on
-        // underflow; .max(0) normalises any negative result to exactly 0.
-        meter.balance = meter.balance.saturating_sub(cost).max(0);
+        meter.balance = meter.balance.checked_sub(cost).unwrap_or(0).max(0);
         let deactivated = if meter.balance == 0 {
             meter.active = false;
             true


### PR DESCRIPTION
closes #66

- checked_sub returns None on arithmetic overflow instead of wrapping or panicking — handles the i128::MIN edge case that saturating_sub would hit
- .unwrap_or(0) makes the overflow fallback explicit and readable
- .max(0) clamps the result for the normal case where cost > balance (no overflow, just a negative result)

The logic is now unambiguous — no implicit reliance on overflow-checks flags in the release profile.