### PR TITLE
fix(frontend): validate publicKey before setting wallet state

### DIFF
--- a/frontend/src/store/walletStore.ts
+++ b/frontend/src/store/walletStore.ts
@@ -36,6 +36,7 @@ export const useWalletStore = create<WalletState>((set, get) => ({
         onWalletSelected: async (option) => {
           kit.setWallet(option.id);
           const { address } = await kit.getAddress();
+          if (!address || address.length < 10) throw new Error("No account found in Freighter");
           set({ address, kit });
         },
       });


### PR DESCRIPTION
closes #69
If Freighter is installed with no accounts configured, getAddress() returns an empty/undefined address. Guard against this by throwing before set() is called — the existing catch block surfaces it as connectError, which drives the error toast.