### PR TITLE
feat: integrate SAC token for payments and revenue withdrawal

### DIFF
--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -8,6 +8,7 @@ use soroban_sdk::{
 
 const ADMIN: Symbol = symbol_short!("ADMIN");
 const ALLOWLIST: Symbol = symbol_short!("ALLOWLIST");
+const TOKEN: Symbol = symbol_short!("TOKEN");
 const SECONDS_PER_DAY: u64 = 86_400;
 const SECONDS_PER_WEEK: u64 = 604_800;
 
@@ -26,11 +27,10 @@ pub enum PaymentPlan {
 pub struct Meter {
     pub owner: Address,
     pub active: bool,
-    pub balance: i128,      // token's smallest unit (e.g., stroops for token with 7 decimals)
-    pub units_used: u64,     // kWh * 1000 (milli-kWh for precision)
+    pub units_used: u64,    // kWh * 1000 (milli-kWh for precision)
     pub plan: PaymentPlan,
-    pub last_payment: u64,   // ledger timestamp
-    pub expires_at: u64,     // ledger timestamp when access expires
+    pub last_payment: u64,  // ledger timestamp
+    pub expires_at: u64,    // ledger timestamp when access expires
 }
 
 #[contracttype]
@@ -38,6 +38,7 @@ pub enum DataKey {
     Meter(Symbol),
     OwnerMeters(Address),
     ProviderRevenue(Address),
+    MeterBalance(Symbol),
 }
 
 // ── Event topics (contract namespace) ────────────────────────────────────────
@@ -50,13 +51,14 @@ pub struct SolarGridContract;
 
 #[contractimpl]
 impl SolarGridContract {
-    /// Initialize the contract with an admin address.
-    pub fn initialize(env: Env, admin: Address) {
+    /// Initialize the contract with an admin address and the SAC token address.
+    pub fn initialize(env: Env, admin: Address, token_address: Address) {
         admin.require_auth();
         if env.storage().instance().has(&ADMIN) {
             panic!("already initialized");
         }
         env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&TOKEN, &token_address);
     }
 
     /// Register a new smart meter for an owner.
@@ -82,7 +84,6 @@ impl SolarGridContract {
         let meter = Meter {
             owner: owner.clone(),
             active: false,
-            balance: 0,
             units_used: 0,
             plan: PaymentPlan::Daily,
             last_payment: env.ledger().timestamp(),
@@ -91,13 +92,13 @@ impl SolarGridContract {
         env.storage().persistent().set(&key, &meter);
 
         // Append meter_id to the owner's meter list
-        let owner_key = DataKey::OwnerMeters(owner);
+        let owner_key = DataKey::OwnerMeters(owner.clone());
         let mut list: Vec<Symbol> = env
             .storage()
             .persistent()
             .get(&owner_key)
             .unwrap_or_else(|| vec![&env]);
-        list.push_back(meter_id);
+        list.push_back(meter_id.clone());
         env.storage().persistent().set(&owner_key, &list);
 
         // meter_registered
@@ -167,7 +168,6 @@ impl SolarGridContract {
     pub fn make_payment(
         env: Env,
         meter_id: Symbol,
-        token_address: Address,
         payer: Address,
         amount: i128,
         plan: PaymentPlan,
@@ -176,13 +176,13 @@ impl SolarGridContract {
         if amount <= 0 {
             panic!("amount must be positive");
         }
+        let token_address: Address = env.storage().instance().get(&TOKEN).expect("not initialized");
         let token_client = token::Client::new(&env, &token_address);
         token_client.transfer(&payer, &env.current_contract_address(), &amount);
 
         let key = DataKey::Meter(meter_id.clone());
         let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
         let now = env.ledger().timestamp();
-        // Exhaustive match guard: compile error if a new variant is added without handling it.
         match plan {
             PaymentPlan::Daily | PaymentPlan::Weekly | PaymentPlan::UsageBased => {}
         }
@@ -191,14 +191,19 @@ impl SolarGridContract {
             PaymentPlan::Weekly => now.saturating_add(SECONDS_PER_WEEK),
             PaymentPlan::UsageBased => u64::MAX,
         };
-        meter.balance += amount;
+
+        // Track per-meter balance in contract storage
+        let bal_key = DataKey::MeterBalance(meter_id.clone());
+        let prev_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        env.storage().persistent().set(&bal_key, &(prev_bal + amount));
+
         meter.active = true;
         meter.plan = plan.clone();
         meter.last_payment = now;
         meter.expires_at = expires_at;
         env.storage().persistent().set(&key, &meter);
 
-        // Track provider (admin) accrued revenue in contract storage.
+        // Track provider (admin) accrued revenue
         let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
         let provider_key = DataKey::ProviderRevenue(admin);
         let provider_revenue: i128 = env.storage().persistent().get(&provider_key).unwrap_or(0);
@@ -211,7 +216,7 @@ impl SolarGridContract {
             (symbol_short!("pmt_rcvd"), EVT_NS, meter_id.clone()),
             (payer, token_address, amount, plan),
         );
-        // meter_activated — payment always activates the meter
+        // meter_activated
         env.events().publish(
             (symbol_short!("mtr_actv"), EVT_NS, meter_id),
             (),
@@ -220,13 +225,8 @@ impl SolarGridContract {
 
     /// Withdraw accumulated revenue from the contract vault to the provider address.
     ///
-    /// Revenue is credited to the admin's `ProviderRevenue` balance on every
-    /// `make_payment` call. This function debits that balance and transfers
-    /// tokens via the SEP-41 token interface.
-    ///
     /// # Access control
-    /// Only the contract admin may call this (`provider` must equal the stored
-    /// admin and must co-sign the transaction).
+    /// Only the contract admin may call this.
     ///
     /// # Panics
     /// - `"amount must be positive"` — if `amount <= 0`
@@ -234,7 +234,7 @@ impl SolarGridContract {
     /// - `"insufficient provider revenue"` — if tracked balance < `amount`
     ///
     /// Emits: `rev_wdrl { provider, token_address, amount }`
-    pub fn withdraw_revenue(env: Env, token_address: Address, provider: Address, amount: i128) {
+    pub fn withdraw_revenue(env: Env, provider: Address, amount: i128) {
         if amount <= 0 {
             panic!("amount must be positive");
         }
@@ -254,6 +254,7 @@ impl SolarGridContract {
             .persistent()
             .set(&provider_key, &(provider_revenue - amount));
 
+        let token_address: Address = env.storage().instance().get(&TOKEN).expect("not initialized");
         let token_client = token::Client::new(&env, &token_address);
         token_client.transfer(&env.current_contract_address(), &provider, &amount);
 
@@ -271,9 +272,11 @@ impl SolarGridContract {
 
     /// Check whether a meter currently has active energy access.
     pub fn check_access(env: Env, meter_id: Symbol) -> bool {
-        let key = DataKey::Meter(meter_id);
+        let key = DataKey::Meter(meter_id.clone());
         let meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
-        meter.active && meter.balance > 0 && env.ledger().timestamp() < meter.expires_at
+        let bal_key = DataKey::MeterBalance(meter_id);
+        let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        meter.active && balance > 0 && env.ledger().timestamp() < meter.expires_at
     }
 
     /// Called by the IoT oracle to record energy consumption (milli-kWh).
@@ -286,9 +289,12 @@ impl SolarGridContract {
         Self::require_admin(&env);
         let key = DataKey::Meter(meter_id.clone());
         let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
+        let bal_key = DataKey::MeterBalance(meter_id.clone());
+        let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        let new_balance = balance.checked_sub(cost).unwrap_or(0).max(0);
+        env.storage().persistent().set(&bal_key, &new_balance);
         meter.units_used += units;
-        meter.balance = meter.balance.checked_sub(cost).unwrap_or(0).max(0);
-        let deactivated = if meter.balance == 0 {
+        let deactivated = if new_balance == 0 {
             meter.active = false;
             true
         } else {
@@ -310,6 +316,12 @@ impl SolarGridContract {
         }
     }
 
+    /// Get the on-chain token balance held by this contract for a specific meter.
+    pub fn get_meter_balance(env: Env, meter_id: Symbol) -> i128 {
+        let bal_key = DataKey::MeterBalance(meter_id);
+        env.storage().persistent().get(&bal_key).unwrap_or(0)
+    }
+
     /// Get meter details.
     pub fn get_meter(env: Env, meter_id: Symbol) -> Meter {
         let key = DataKey::Meter(meter_id);
@@ -325,8 +337,12 @@ impl SolarGridContract {
         Self::require_admin(&env);
         let key = DataKey::Meter(meter_id.clone());
         let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
-        if active && meter.balance == 0 {
-            panic!("cannot activate meter with zero balance");
+        if active {
+            let bal_key = DataKey::MeterBalance(meter_id.clone());
+            let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+            if balance == 0 {
+                panic!("cannot activate meter with zero balance");
+            }
         }
         meter.active = active;
         env.storage().persistent().set(&key, &meter);
@@ -359,9 +375,13 @@ mod tests {
     use super::*;
     use soroban_sdk::{
         symbol_short,
-        testutils::{Address as _, Ledger},
-        token, Address, Env,
+        testutils::{Address as _, Events, Ledger},
+        token, Address, Env, Symbol, TryFromVal,
     };
+
+    fn sym_eq(env: &Env, val: &soroban_sdk::Val, expected: Symbol) -> bool {
+        Symbol::try_from_val(env, val).ok() == Some(expected)
+    }
 
     fn setup() -> (Env, SolarGridContractClient<'static>, Address) {
         let env = Env::default();
@@ -369,7 +389,11 @@ mod tests {
         let contract_id = env.register_contract(None, SolarGridContract);
         let client = SolarGridContractClient::new(&env, &contract_id);
         let admin = Address::generate(&env);
-        client.initialize(&admin);
+        let token_admin = Address::generate(&env);
+        let token_address = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        client.initialize(&admin, &token_address);
         (env, client, admin)
     }
 
@@ -393,32 +417,40 @@ mod tests {
         (token_address, token_admin_client, token_client)
     }
 
+    /// Setup with a specific token registered in initialize.
+    /// Returns (env, client, admin, token_address).
+    /// Callers can construct token clients from token_address as needed.
+    fn setup_with_token() -> (Env, SolarGridContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SolarGridContract);
+        let client = SolarGridContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_address = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        client.initialize(&admin, &token_address);
+        (env, client, admin, token_address)
+    }
+
     #[test]
     fn test_register_and_pay() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, token_client) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+        let token_client = token::Client::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER1");
 
         allowlist_and_register(&client, &meter_id, &user);
-
-        // Before payment — inactive
         assert!(!client.check_access(&meter_id));
 
         token_admin_client.mint(&user, &5_000_000_i128);
-        // Make payment
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &5_000_000_i128,
-            &PaymentPlan::Daily,
-        );
+        client.make_payment(&meter_id, &user, &5_000_000_i128, &PaymentPlan::Daily);
         assert!(client.check_access(&meter_id));
         assert_eq!(token_client.balance(&user), 0);
 
-        // Simulate usage that drains balance
         client.update_usage(&meter_id, &100_u64, &5_000_000_i128);
         assert!(!client.check_access(&meter_id));
     }
@@ -427,14 +459,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "meter already registered")]
     fn test_register_meter_duplicate_panics() {
-        let (env, client, _admin) = setup();
-        let _ = setup_token(&env);
-
+        let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER2");
-
         allowlist_and_register(&client, &meter_id, &user);
-        // Second registration with the same id must panic
         client.register_meter(&meter_id, &user);
     }
 
@@ -442,163 +470,119 @@ mod tests {
     #[test]
     #[should_panic(expected = "amount must be positive")]
     fn test_make_payment_zero_amount_panics() {
-        let (env, client, _admin) = setup();
-        let (token_address, _token_admin_client, _token_client) = setup_token(&env);
-
+        let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER3");
-
         allowlist_and_register(&client, &meter_id, &user);
-        client.make_payment(&meter_id, &token_address, &user, &0_i128, &PaymentPlan::Daily);
+        client.make_payment(&meter_id, &user, &0_i128, &PaymentPlan::Daily);
     }
 
-    /// make_payment with a negative amount should panic.
     #[test]
     #[should_panic(expected = "amount must be positive")]
     fn test_make_payment_negative_amount_panics() {
-        let (env, client, _admin) = setup();
-        let (token_address, _token_admin_client, _token_client) = setup_token(&env);
-
+        let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER4");
-
         allowlist_and_register(&client, &meter_id, &user);
-        client.make_payment(&meter_id, &token_address, &user, &-1_i128, &PaymentPlan::Daily);
+        client.make_payment(&meter_id, &user, &-1_i128, &PaymentPlan::Daily);
     }
 
-    /// update_usage drains balance correctly and deactivates at zero.
     #[test]
     fn test_update_usage_balance_drains_correctly() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _token_client) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER5");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &10_000_000_i128);
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &10_000_000_i128,
-            &PaymentPlan::UsageBased,
-        );
+        client.make_payment(&meter_id, &user, &10_000_000_i128, &PaymentPlan::UsageBased);
 
-        // Partial drain — meter stays active
         client.update_usage(&meter_id, &50_u64, &4_000_000_i128);
+        assert_eq!(client.get_meter_balance(&meter_id), 6_000_000);
         let meter = client.get_meter(&meter_id);
-        assert_eq!(meter.balance, 6_000_000);
         assert_eq!(meter.units_used, 50);
         assert!(meter.active);
 
-        // Drain the rest — meter deactivates
         client.update_usage(&meter_id, &60_u64, &6_000_000_i128);
+        assert_eq!(client.get_meter_balance(&meter_id), 0);
         let meter = client.get_meter(&meter_id);
-        assert_eq!(meter.balance, 0);
         assert_eq!(meter.units_used, 110);
         assert!(!meter.active);
     }
 
-    /// update_usage with a huge cost should clamp balance to zero without panic.
     #[test]
     fn test_update_usage_huge_cost_clamps_to_zero() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _token_client) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER9");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &100_i128);
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &100_i128,
-            &PaymentPlan::UsageBased,
-        );
+        client.make_payment(&meter_id, &user, &100_i128, &PaymentPlan::UsageBased);
 
         client.update_usage(&meter_id, &1_u64, &i128::MAX);
+        assert_eq!(client.get_meter_balance(&meter_id), 0);
         let meter = client.get_meter(&meter_id);
-        assert_eq!(meter.balance, 0);
         assert_eq!(meter.units_used, 1);
         assert!(!meter.active);
     }
-    /// check_access returns false when balance is zero even if active flag is true.
     #[test]
     fn test_check_access_false_when_balance_zero() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _token_client) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER7");
 
         allowlist_and_register(&client, &meter_id, &user);
-
-        // Newly registered meter: active=false, balance=0
         assert!(!client.check_access(&meter_id));
 
-        // Pay then fully drain
         token_admin_client.mint(&user, &2_000_000_i128);
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &2_000_000_i128,
-            &PaymentPlan::Weekly,
-        );
+        client.make_payment(&meter_id, &user, &2_000_000_i128, &PaymentPlan::Weekly);
         assert!(client.check_access(&meter_id));
 
         client.update_usage(&meter_id, &10_u64, &2_000_000_i128);
         assert!(!client.check_access(&meter_id));
 
-        let meter = client.get_meter(&meter_id);
-        assert_eq!(meter.balance, 0);
-        assert!(!meter.active);
+        assert_eq!(client.get_meter_balance(&meter_id), 0);
+        assert!(!client.get_meter(&meter_id).active);
     }
 
     /// Daily plans should auto-expire after 24 hours even with remaining balance.
     #[test]
+    #[test]
     fn test_check_access_false_when_plan_expired() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _token_client) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER9");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &2_000_000_i128);
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &2_000_000_i128,
-            &PaymentPlan::Daily,
-        );
+        client.make_payment(&meter_id, &user, &2_000_000_i128, &PaymentPlan::Daily);
         assert!(client.check_access(&meter_id));
 
         let meter = client.get_meter(&meter_id);
-        env.ledger().with_mut(|li| {
-            li.timestamp = meter.expires_at;
-        });
-
-        // Access should be denied exactly at expiry boundary.
+        env.ledger().with_mut(|li| { li.timestamp = meter.expires_at; });
         assert!(!client.check_access(&meter_id));
     }
 
-    /// Weekly plan should auto-expire after 7 days even with remaining balance.
     #[test]
     fn test_check_access_false_when_weekly_plan_expired() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("WK_EXP");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &5_000_000_i128);
-        client.make_payment(&meter_id, &token_address, &user, &5_000_000_i128, &PaymentPlan::Weekly);
+        client.make_payment(&meter_id, &user, &5_000_000_i128, &PaymentPlan::Weekly);
         assert!(client.check_access(&meter_id));
 
         let meter = client.get_meter(&meter_id);
@@ -608,47 +592,42 @@ mod tests {
         assert!(!client.check_access(&meter_id));
     }
 
-    /// UsageBased plan never expires by time — only balance gates access.
     #[test]
     fn test_usage_based_plan_never_expires_by_time() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("UB_EXP");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &1_000_i128);
-        client.make_payment(&meter_id, &token_address, &user, &1_000_i128, &PaymentPlan::UsageBased);
+        client.make_payment(&meter_id, &user, &1_000_i128, &PaymentPlan::UsageBased);
 
         let meter = client.get_meter(&meter_id);
         assert_eq!(meter.expires_at, u64::MAX);
 
-        // Far future — still active because balance > 0 and expires_at = u64::MAX
         env.ledger().with_mut(|li| li.timestamp = u64::MAX - 1);
         assert!(client.check_access(&meter_id));
     }
 
-    /// Renewal (top-up) after expiry resets expires_at and restores access.
     #[test]
     fn test_renewal_resets_expiry_and_restores_access() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("RENEW");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &4_000_000_i128);
-        client.make_payment(&meter_id, &token_address, &user, &2_000_000_i128, &PaymentPlan::Daily);
+        client.make_payment(&meter_id, &user, &2_000_000_i128, &PaymentPlan::Daily);
 
         let meter = client.get_meter(&meter_id);
-        // Advance past expiry
         env.ledger().with_mut(|li| li.timestamp = meter.expires_at);
         assert!(!client.check_access(&meter_id));
 
-        // Top-up renews the plan from the new timestamp
-        client.make_payment(&meter_id, &token_address, &user, &2_000_000_i128, &PaymentPlan::Daily);
+        client.make_payment(&meter_id, &user, &2_000_000_i128, &PaymentPlan::Daily);
         assert!(client.check_access(&meter_id));
 
         let renewed = client.get_meter(&meter_id);
@@ -707,26 +686,21 @@ mod tests {
 
     #[test]
     fn test_withdraw_revenue_tracks_and_withdraws_provider_balance() {
-        let (env, client, admin) = setup();
-        let (token_address, token_admin_client, token_client) = setup_token(&env);
+        let (env, client, admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+        let token_client = token::Client::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER9");
         allowlist_and_register(&client, &meter_id, &user);
 
         token_admin_client.mint(&user, &5_000_000_i128);
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &5_000_000_i128,
-            &PaymentPlan::Daily,
-        );
+        client.make_payment(&meter_id, &user, &5_000_000_i128, &PaymentPlan::Daily);
 
         assert_eq!(client.get_provider_revenue(&admin), 5_000_000_i128);
         assert_eq!(token_client.balance(&client.address), 5_000_000_i128);
 
-        client.withdraw_revenue(&token_address, &admin, &2_000_000_i128);
+        client.withdraw_revenue(&admin, &2_000_000_i128);
         assert_eq!(client.get_provider_revenue(&admin), 3_000_000_i128);
         assert_eq!(token_client.balance(&client.address), 3_000_000_i128);
         assert_eq!(token_client.balance(&admin), 2_000_000_i128);
@@ -735,41 +709,28 @@ mod tests {
     #[test]
     #[should_panic(expected = "insufficient provider revenue")]
     fn test_withdraw_revenue_panics_when_amount_exceeds_tracked_balance() {
-        let (env, client, admin) = setup();
-        let (token_address, _token_admin_client, _token_client) = setup_token(&env);
-
+        let (env, client, admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METR10");
         allowlist_and_register(&client, &meter_id, &user);
-
-        client.withdraw_revenue(&token_address, &admin, &1_i128);
+        client.withdraw_revenue(&admin, &1_i128);
     }
 
-    /// Exact-balance drain: cost == balance should deactivate the meter.
-    /// Regression test for the `<= 0` vs `== 0` edge case.
     #[test]
     fn test_update_usage_exact_balance_deactivates_meter() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
 
         let user = Address::generate(&env);
         let meter_id = symbol_short!("EXACT");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &5_000_000_i128);
-        client.make_payment(
-            &meter_id,
-            &token_address,
-            &user,
-            &5_000_000_i128,
-            &PaymentPlan::UsageBased,
-        );
+        client.make_payment(&meter_id, &user, &5_000_000_i128, &PaymentPlan::UsageBased);
 
-        // cost == balance exactly
         client.update_usage(&meter_id, &1_u64, &5_000_000_i128);
-        let meter = client.get_meter(&meter_id);
-        assert_eq!(meter.balance, 0, "balance should be 0");
-        assert!(!meter.active, "meter should be deactivated when balance hits 0");
+        assert_eq!(client.get_meter_balance(&meter_id), 0, "balance should be 0");
+        assert!(!client.get_meter(&meter_id).active, "meter should be deactivated when balance hits 0");
     }
 
     // ── Event emission tests ──────────────────────────────────────────────────
@@ -778,12 +739,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "cannot activate meter with zero balance")]
     fn test_set_active_true_panics_when_balance_zero() {
-        let (env, client, _admin) = setup();
+        let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("ZERO_BAL");
-
         allowlist_and_register(&client, &meter_id, &user);
-        // Meter has balance=0 right after registration — activating must panic.
         client.set_active(&meter_id, &true);
     }
 
@@ -799,29 +758,29 @@ mod tests {
         let events = env.events().all();
         let found = events.iter().any(|(_, topics, _)| {
             topics.len() >= 2
-                && topics.get(0) == Some(symbol_short!("mtr_reg").into())
-                && topics.get(1) == Some(EVT_NS.into())
+                && topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("mtr_reg"))).unwrap_or(false)
+                && topics.get(1).map(|v| sym_eq(&env, &v, EVT_NS)).unwrap_or(false)
         });
         assert!(found, "mtr_reg event not emitted");
     }
 
     #[test]
     fn test_event_payment_received_and_meter_activated() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
         let user = Address::generate(&env);
         let meter_id = symbol_short!("EV_PMT");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &1_000_000_i128);
-        client.make_payment(&meter_id, &token_address, &user, &1_000_000_i128, &PaymentPlan::Daily);
+        client.make_payment(&meter_id, &user, &1_000_000_i128, &PaymentPlan::Daily);
 
         let events = env.events().all();
         let has_pmt = events.iter().any(|(_, topics, _)| {
-            topics.get(0) == Some(symbol_short!("pmt_rcvd").into())
+            topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("pmt_rcvd"))).unwrap_or(false)
         });
         let has_actv = events.iter().any(|(_, topics, _)| {
-            topics.get(0) == Some(symbol_short!("mtr_actv").into())
+            topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("mtr_actv"))).unwrap_or(false)
         });
         assert!(has_pmt, "pmt_rcvd event not emitted");
         assert!(has_actv, "mtr_actv event not emitted");
@@ -829,24 +788,23 @@ mod tests {
 
     #[test]
     fn test_event_usage_updated_and_meter_deactivated() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
         let user = Address::generate(&env);
         let meter_id = symbol_short!("EV_USG");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &500_i128);
-        client.make_payment(&meter_id, &token_address, &user, &500_i128, &PaymentPlan::UsageBased);
+        client.make_payment(&meter_id, &user, &500_i128, &PaymentPlan::UsageBased);
 
-        // Drain balance fully — triggers both usg_upd and mtr_deact
         client.update_usage(&meter_id, &10_u64, &500_i128);
 
         let events = env.events().all();
         let has_usg = events.iter().any(|(_, topics, _)| {
-            topics.get(0) == Some(symbol_short!("usg_upd").into())
+            topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("usg_upd"))).unwrap_or(false)
         });
         let has_deact = events.iter().any(|(_, topics, _)| {
-            topics.get(0) == Some(symbol_short!("mtr_deact").into())
+            topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("mtr_deact"))).unwrap_or(false)
         });
         assert!(has_usg, "usg_upd event not emitted");
         assert!(has_deact, "mtr_deact event not emitted on balance drain");
@@ -854,43 +812,42 @@ mod tests {
 
     #[test]
     fn test_event_meter_deactivated_via_set_active() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
         let user = Address::generate(&env);
         let meter_id = symbol_short!("EV_SET");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &1_000_i128);
-        client.make_payment(&meter_id, &token_address, &user, &1_000_i128, &PaymentPlan::Daily);
+        client.make_payment(&meter_id, &user, &1_000_i128, &PaymentPlan::Daily);
 
         client.set_active(&meter_id, &false);
 
         let events = env.events().all();
         let has_deact = events.iter().any(|(_, topics, _)| {
-            topics.get(0) == Some(symbol_short!("mtr_deact").into())
+            topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("mtr_deact"))).unwrap_or(false)
         });
         assert!(has_deact, "mtr_deact event not emitted by set_active(false)");
     }
 
     #[test]
     fn test_event_meter_activated_via_set_active() {
-        let (env, client, _admin) = setup();
-        let (token_address, token_admin_client, _) = setup_token(&env);
+        let (env, client, _admin, token_address) = setup_with_token();
+        let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
         let user = Address::generate(&env);
         let meter_id = symbol_short!("EV_ON");
 
         allowlist_and_register(&client, &meter_id, &user);
         token_admin_client.mint(&user, &1_000_i128);
-        client.make_payment(&meter_id, &token_address, &user, &1_000_i128, &PaymentPlan::Daily);
-        // Deactivate first so we can re-activate
+        client.make_payment(&meter_id, &user, &1_000_i128, &PaymentPlan::Daily);
         client.set_active(&meter_id, &false);
 
         client.set_active(&meter_id, &true);
 
         let events = env.events().all();
         let has_actv = events.iter().any(|(_, topics, _)| {
-            topics.get(0) == Some(symbol_short!("mtr_actv").into())
-                && topics.get(1) == Some(EVT_NS.into())
+            topics.get(0).map(|v| sym_eq(&env, &v, symbol_short!("mtr_actv"))).unwrap_or(false)
+                && topics.get(1).map(|v| sym_eq(&env, &v, EVT_NS)).unwrap_or(false)
         });
         assert!(has_actv, "mtr_actv event not emitted by set_active(true)");
     }


### PR DESCRIPTION
closes #92
- Store token_address in contract storage during initialize
- Remove manual balance field from Meter struct
- Track per-meter balance in MeterBalance storage key
- make_payment reads token from storage, performs real SAC transfer
- withdraw_revenue reads token from storage, no longer takes token_address param
- Add get_meter_balance() public helper
- Add DataKey::MeterBalance variant
- Update all tests to use setup_with_token() and mock SAC token
- Fix event topic comparisons to use TryFromVal (Val has no PartialEq)

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- Bullet-point list of the key changes. Focus on the *why*, not just the *what*. -->

-
-

## How to Test

<!-- Steps a reviewer can follow to verify the change works correctly. -->

1.
2.

## Checklist

- [ ] Code builds without errors (`cargo build` / `npm run build`)
- [ ] No TypeScript errors (`tsc --noEmit`)
- [ ] Rust code is formatted (`cargo fmt`) and lint-clean (`cargo clippy -- -D warnings`)
- [ ] No unintended breaking changes to existing functionality
- [ ] PR targets the `main` branch and is rebased on the latest upstream

## Screenshots (if applicable)

<!-- Delete this section if not relevant. -->
