### PR TITLE
feat: add get_meters_by_owner + owner index + multi-meter UserDashboard

### DIFF
--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -872,6 +872,25 @@ mod tests {
         assert!(has_deact, "mtr_deact event not emitted by set_active(false)");
     }
 
+    /// register 3 meters for the same owner — get_meters_by_owner returns all 3.
+    #[test]
+    fn test_get_meters_by_owner_returns_all() {
+        let (env, client, _admin) = setup();
+        let user = Address::generate(&env);
+        let ids = [symbol_short!("OWN_A"), symbol_short!("OWN_B"), symbol_short!("OWN_C")];
+
+        client.allowlist_add(&user);
+        for id in &ids {
+            client.register_meter(id, &user);
+        }
+
+        let meters = client.get_meters_by_owner(&user);
+        assert_eq!(meters.len(), 3);
+        for id in &ids {
+            assert!(meters.contains(id));
+        }
+    }
+
     #[test]
     fn test_event_meter_activated_via_set_active() {
         let (env, client, _admin) = setup();

--- a/frontend/src/app/dashboard/user/page.tsx
+++ b/frontend/src/app/dashboard/user/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
 import { useWalletStore } from "@/store/walletStore";
-import { getMeter, type MeterData } from "@/services/meterService";
+import { getMeter, getMetersByOwner, type MeterData } from "@/services/meterService";
 import { parseWalletError } from "@/lib/errors";
 
 const STROOPS_PER_XLM = 10_000_000n;
@@ -24,9 +24,7 @@ function StatusBadge({ active }: { active: boolean }) {
           : "border-red-600/40 bg-red-900/30 text-red-400"
       }`}
     >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${active ? "bg-green-400" : "bg-red-400"}`}
-      />
+      <span className={`h-1.5 w-1.5 rounded-full ${active ? "bg-green-400" : "bg-red-400"}`} />
       {active ? "Active" : "Inactive"}
     </span>
   );
@@ -47,22 +45,48 @@ function PlanBadge({ plan }: { plan: string }) {
   );
 }
 
-function StatCard({
-  label,
-  value,
-  sub,
-}: {
-  label: string;
-  value: React.ReactNode;
-  sub?: string;
-}) {
+function MeterCard({ meterId, meter }: { meterId: string; meter: MeterData }) {
   return (
-    <div className="rounded-xl border border-white/10 bg-solar-accent p-5 flex flex-col gap-1">
-      <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">
-        {label}
-      </span>
-      <span className="text-2xl font-bold text-white">{value}</span>
-      {sub && <span className="text-xs text-gray-500">{sub}</span>}
+    <div className="rounded-xl border border-white/10 bg-solar-accent p-5 space-y-4">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-mono text-sm text-solar-yellow font-semibold">{meterId}</span>
+        <div className="flex items-center gap-2">
+          <StatusBadge active={meter.active} />
+          <PlanBadge plan={meter.plan} />
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[
+          { label: "Balance", value: `${stroopsToXlm(meter.balance)} XLM` },
+          { label: "Units Used", value: `${meter.units_used} kWh` },
+          { label: "Last Payment", value: meter.last_payment > 0n ? new Date(Number(meter.last_payment) * 1000).toLocaleDateString() : "—" },
+          { label: "Owner", value: `${meter.owner.slice(0, 6)}…${meter.owner.slice(-4)}` },
+        ].map(({ label, value }) => (
+          <div key={label} className="flex flex-col gap-0.5">
+            <span className="text-xs uppercase tracking-wider text-gray-500">{label}</span>
+            <span className="text-sm font-semibold text-white truncate">{value}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-2 pt-1">
+        <Link
+          href={`/pay?meter=${meterId}`}
+          className="rounded-lg bg-solar-yellow px-4 py-2 text-xs font-semibold text-solar-dark hover:opacity-90 transition"
+        >
+          Top Up
+        </Link>
+        <Link
+          href="/history"
+          className="rounded-lg border border-white/10 px-4 py-2 text-xs text-gray-300 hover:border-solar-yellow hover:text-solar-yellow transition"
+        >
+          History
+        </Link>
+      </div>
     </div>
   );
 }
@@ -70,47 +94,48 @@ function StatCard({
 export default function UserDashboardPage() {
   const { address, connect } = useWalletStore();
 
-  // meterId is the wallet address itself (owner = address on-chain)
-  const meterId = address ?? "";
-
-  const [meter, setMeter] = useState<MeterData | null>(null);
+  const [meterIds, setMeterIds] = useState<string[]>([]);
+  const [meters, setMeters] = useState<Record<string, MeterData>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
-  const fetchMeterData = useCallback(async () => {
-    if (!meterId) return;
+  const fetchAll = useCallback(async () => {
+    if (!address) return;
     setLoading(true);
     setError(null);
     try {
-      const data = await getMeter(meterId);
-      setMeter(data);
+      const ids = await getMetersByOwner(address);
+      setMeterIds(ids);
+      const entries = await Promise.all(ids.map((id) => getMeter(id).then((m) => [id, m] as const)));
+      setMeters(Object.fromEntries(entries));
       setLastRefresh(new Date());
     } catch (err: unknown) {
       setError(parseWalletError(err));
     } finally {
       setLoading(false);
     }
-  }, [meterId]);
+  }, [address]);
 
-  // Clear stale data immediately when wallet disconnects, fetch when connected
   useEffect(() => {
     if (!address) {
-      setMeter(null);
+      setMeterIds([]);
+      setMeters({});
       setError(null);
       setLastRefresh(null);
       return;
     }
-    fetchMeterData();
-  }, [address, fetchMeterData]);
+    fetchAll();
+  }, [address, fetchAll]);
 
   return (
     <>
       <Navbar />
       <main className="min-h-screen px-4 py-8 max-w-3xl mx-auto">
+        {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold text-solar-yellow">My Meter</h1>
+            <h1 className="text-2xl sm:text-3xl font-bold text-solar-yellow">My Meters</h1>
             {lastRefresh && (
               <p className="text-xs text-gray-500 mt-0.5">
                 Last updated {lastRefresh.toLocaleTimeString()}
@@ -119,7 +144,7 @@ export default function UserDashboardPage() {
           </div>
           {address && (
             <button
-              onClick={fetchMeterData}
+              onClick={fetchAll}
               disabled={loading}
               className="self-start sm:self-auto rounded-lg border border-white/10 px-4 py-2 text-sm text-gray-300 hover:border-solar-yellow hover:text-solar-yellow disabled:opacity-40 disabled:cursor-not-allowed transition"
             >
@@ -131,7 +156,7 @@ export default function UserDashboardPage() {
         {/* Not connected */}
         {!address && (
           <div className="rounded-xl border border-white/10 bg-solar-accent p-10 text-center">
-            <p className="text-gray-400 mb-5">Connect your wallet to view your meter.</p>
+            <p className="text-gray-400 mb-5">Connect your wallet to view your meters.</p>
             <button
               onClick={connect}
               className="rounded-lg bg-solar-yellow px-6 py-2.5 font-semibold text-solar-dark hover:opacity-90 transition"
@@ -146,12 +171,9 @@ export default function UserDashboardPage() {
           <div className="rounded-lg border border-red-500/40 bg-red-900/20 p-4 text-red-400 text-sm mb-6 flex items-start gap-3">
             <span className="mt-0.5">✕</span>
             <div>
-              <p className="font-semibold mb-1">Failed to load meter data</p>
+              <p className="font-semibold mb-1">Failed to load meters</p>
               <p>{error}</p>
-              <button
-                onClick={fetchMeterData}
-                className="mt-3 text-xs underline underline-offset-2 hover:text-red-300 transition"
-              >
+              <button onClick={fetchAll} className="mt-3 text-xs underline underline-offset-2 hover:text-red-300 transition">
                 Try again
               </button>
             </div>
@@ -159,78 +181,31 @@ export default function UserDashboardPage() {
         )}
 
         {/* Loading skeleton */}
-        {address && loading && !meter && (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 animate-pulse">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="rounded-xl border border-white/10 bg-solar-accent p-5 h-24"
-              />
+        {address && loading && meterIds.length === 0 && (
+          <div className="space-y-4 animate-pulse">
+            {[0, 1].map((i) => (
+              <div key={i} className="rounded-xl border border-white/10 bg-solar-accent p-5 h-36" />
             ))}
           </div>
         )}
 
-        {/* Meter data */}
-        {address && meter && (
-          <div className="space-y-6">
-            {/* Status row */}
-            <div className="flex flex-wrap items-center gap-3">
-              <StatusBadge active={meter.active} />
-              <PlanBadge plan={meter.plan} />
-              <span className="text-xs text-gray-500 font-mono truncate max-w-xs">
-                {meter.owner}
-              </span>
-            </div>
+        {/* No meters */}
+        {address && !loading && !error && meterIds.length === 0 && (
+          <div className="rounded-xl border border-white/10 bg-solar-accent p-10 text-center text-gray-400 text-sm">
+            No meters registered to this address.
+          </div>
+        )}
 
-            {/* Stat cards */}
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-              <StatCard
-                label="Balance"
-                value={`${stroopsToXlm(meter.balance)} XLM`}
-                sub="on-chain balance"
-              />
-              <StatCard
-                label="Units Used"
-                value={meter.units_used.toString()}
-                sub="kWh consumed"
-              />
-              <StatCard
-                label="Plan"
-                value={<PlanBadge plan={meter.plan} />}
-                sub="billing cycle"
-              />
-              <StatCard
-                label="Status"
-                value={<StatusBadge active={meter.active} />}
-                sub="meter state"
-              />
-            </div>
-
-            {/* Last payment */}
-            {meter.last_payment > 0n && (
-              <div className="rounded-xl border border-white/10 bg-solar-accent px-5 py-4 text-sm text-gray-400">
-                Last payment:{" "}
-                <span className="text-white font-medium">
-                  {new Date(Number(meter.last_payment) * 1000).toLocaleString()}
-                </span>
-              </div>
+        {/* Meter list */}
+        {address && meterIds.length > 0 && (
+          <div className="space-y-4">
+            {meterIds.map((id) =>
+              meters[id] ? (
+                <MeterCard key={id} meterId={id} meter={meters[id]} />
+              ) : (
+                <div key={id} className="rounded-xl border border-white/10 bg-solar-accent p-5 h-36 animate-pulse" />
+              )
             )}
-
-            {/* Actions */}
-            <div className="flex flex-col sm:flex-row gap-3">
-              <Link
-                href={`/pay`}
-                className="rounded-lg bg-solar-yellow px-6 py-3 text-center font-semibold text-solar-dark hover:opacity-90 transition"
-              >
-                Top Up Balance
-              </Link>
-              <Link
-                href="/history"
-                className="rounded-lg border border-white/10 px-6 py-3 text-center text-sm text-gray-300 hover:border-solar-yellow hover:text-solar-yellow transition"
-              >
-                View Payment History
-              </Link>
-            </div>
           </div>
         )}
       </main>

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -83,3 +83,31 @@ export async function contractInvoke(
   }
   return result.hash;
 }
+
+/** Return all meter IDs registered under the given owner address. */
+export async function fetchMetersByOwner(ownerAddress: string): Promise<string[]> {
+  const contract = new StellarSdk.Contract(CONTRACT_ID);
+  const keypair = StellarSdk.Keypair.random();
+  const account = new StellarSdk.Account(keypair.publicKey(), "0");
+
+  const tx = new StellarSdk.TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "get_meters_by_owner",
+        StellarSdk.nativeToScVal(ownerAddress, { type: "address" })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (StellarSdk.SorobanRpc.Api.isSimulationError(sim)) {
+    throw new Error(sim.error);
+  }
+  const retval = (sim as StellarSdk.SorobanRpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+  if (!retval) return [];
+  return StellarSdk.scValToNative(retval) as string[];
+}

--- a/frontend/src/services/meterService.ts
+++ b/frontend/src/services/meterService.ts
@@ -1,10 +1,14 @@
-import { fetchMeter, contractInvoke, type MeterData } from "@/lib/contract";
+import { fetchMeter, fetchMetersByOwner, contractInvoke, type MeterData } from "@/lib/contract";
 import * as StellarSdk from "@stellar/stellar-sdk";
 
 export type { MeterData };
 
 export async function getMeter(meterId: string): Promise<MeterData> {
   return fetchMeter(meterId);
+}
+
+export async function getMetersByOwner(ownerAddress: string): Promise<string[]> {
+  return fetchMetersByOwner(ownerAddress);
 }
 
 export async function makePayment(


### PR DESCRIPTION
Contract:
- DataKey::OwnerMeters(Address) index already present; register_meter appends meter_id to owner's list on every registration
- get_meters_by_owner(owner) -> Vec<Symbol> returns all meter IDs
- test_get_meters_by_owner_returns_all: register 3 meters, verify all returned

Frontend:
- fetchMetersByOwner() added to lib/contract.ts (read-only simulation)
- getMetersByOwner() exported from services/meterService.ts
- UserDashboard rewritten: fetches owner's meter list then loads each meter in parallel; renders a MeterCard per meter with Top Up + History actions; handles empty state, loading skeleton, and errors

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

Closes #108

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- Bullet-point list of the key changes. Focus on the *why*, not just the *what*. -->

-
-

## How to Test

<!-- Steps a reviewer can follow to verify the change works correctly. -->

1.
2.

## Checklist

- [ ] Code builds without errors (`cargo build` / `npm run build`)
- [ ] No TypeScript errors (`tsc --noEmit`)
- [ ] Rust code is formatted (`cargo fmt`) and lint-clean (`cargo clippy -- -D warnings`)
- [ ] No unintended breaking changes to existing functionality
- [ ] PR targets the `main` branch and is rebased on the latest upstream

## Screenshots (if applicable)

<!-- Delete this section if not relevant. -->
