### PR TITLE
feat(frontend): add offline/SMS payment fallback UI (#26)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,5 @@ NEXT_PUBLIC_CONTRACT_ID=YOUR_CONTRACT_ID_HERE
 NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
+NEXT_PUBLIC_SMS_SHORTCODE=20880
+NEXT_PUBLIC_SMS_WEBHOOK_DOCS=https://github.com/damiedee96/Stellar-Solar-Grid/blob/main/backend/README.md

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -2,3 +2,5 @@ NEXT_PUBLIC_CONTRACT_ID=YOUR_CONTRACT_ID_HERE
 NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
+NEXT_PUBLIC_SMS_SHORTCODE=20880
+NEXT_PUBLIC_SMS_WEBHOOK_DOCS=https://github.com/damiedee96/Stellar-Solar-Grid/blob/main/backend/README.md

--- a/frontend/src/app/pay/page.tsx
+++ b/frontend/src/app/pay/page.tsx
@@ -3,7 +3,9 @@
 import { useState } from "react";
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
+import OfflinePaymentModal from "@/components/OfflinePaymentModal";
 import { useWalletStore } from "@/store/walletStore";
+import { useOffline } from "@/hooks/useOffline";
 import { makePayment } from "@/services/meterService";
 import { parseWalletError } from "@/lib/errors";
 
@@ -11,20 +13,22 @@ type Plan = "Daily" | "Weekly" | "Usage";
 type Status = "idle" | "loading" | "success" | "error" | "cancelled";
 
 const PLANS: { value: Plan; label: string; desc: string }[] = [
-  { value: "Daily", label: "Daily", desc: "Billed every 24 hours" },
-  { value: "Weekly", label: "Weekly", desc: "Billed every 7 days" },
-  { value: "Usage", label: "Usage-Based", desc: "Pay per kWh consumed" },
+  { value: "Daily",  label: "Daily",       desc: "Billed every 24 hours" },
+  { value: "Weekly", label: "Weekly",      desc: "Billed every 7 days"   },
+  { value: "Usage",  label: "Usage-Based", desc: "Pay per kWh consumed"  },
 ];
 
 export default function PayPage() {
   const { address, connect } = useWalletStore();
+  const isOffline = useOffline();
 
-  const [meterId, setMeterId] = useState("");
-  const [amount, setAmount] = useState("");
-  const [plan, setPlan] = useState<Plan>("Daily");
-  const [status, setStatus] = useState<Status>("idle");
-  const [message, setMessage] = useState("");
-  const [txHash, setTxHash] = useState("");
+  const [meterId, setMeterId]     = useState("");
+  const [amount, setAmount]       = useState("");
+  const [plan, setPlan]           = useState<Plan>("Daily");
+  const [status, setStatus]       = useState<Status>("idle");
+  const [message, setMessage]     = useState("");
+  const [txHash, setTxHash]       = useState("");
+  const [showSmsModal, setShowSmsModal] = useState(false);
 
   const EXPLORER_BASE = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE?.includes("Test")
     ? "https://stellar.expert/explorer/testnet/tx"
@@ -48,11 +52,7 @@ export default function PayPage() {
       setMessage("Payment successful!");
     } catch (err: unknown) {
       const friendly = parseWalletError(err);
-      if (friendly === "Transaction cancelled by user.") {
-        setStatus("cancelled");
-      } else {
-        setStatus("error");
-      }
+      setStatus(friendly === "Transaction cancelled by user." ? "cancelled" : "error");
       setMessage(friendly);
     }
   }
@@ -66,22 +66,83 @@ export default function PayPage() {
   return (
     <>
       <Navbar />
+
+      {/* ── Offline banner — always visible when offline ── */}
+      {isOffline && (
+        <div className="bg-yellow-900/30 border-b border-yellow-500/30 px-4 py-2.5 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-yellow-300 text-xs">
+            <span>📵</span>
+            <span>You're offline — blockchain payments unavailable.</span>
+          </div>
+          <button
+            onClick={() => setShowSmsModal(true)}
+            className="shrink-0 rounded-lg bg-solar-yellow px-3 py-1.5 text-xs font-semibold text-solar-dark hover:opacity-90 transition"
+          >
+            Pay via SMS
+          </button>
+        </div>
+      )}
+
       <main className="min-h-screen flex items-start justify-center px-4 py-8 sm:py-16">
         <div className="w-full max-w-md">
-          <h1 className="text-2xl sm:text-3xl font-bold text-solar-yellow mb-2">Make a Payment</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-solar-yellow mb-2">
+            Make a Payment
+          </h1>
           <p className="text-gray-400 text-sm mb-6">
             Top up your meter balance on the Stellar blockchain.
           </p>
+
+          {/* ── SMS fallback card — shown when offline ── */}
+          {isOffline && (
+            <div className="mb-6 rounded-xl border border-yellow-500/30 bg-yellow-900/10 p-5">
+              <div className="flex items-start gap-3">
+                <span className="text-2xl mt-0.5">📱</span>
+                <div className="flex-1">
+                  <p className="text-sm font-semibold text-yellow-300 mb-1">
+                    No internet connection
+                  </p>
+                  <p className="text-xs text-gray-400 mb-3">
+                    You can still top up your meter by sending an SMS. No smartphone or data required.
+                  </p>
+                  <button
+                    onClick={() => setShowSmsModal(true)}
+                    className="rounded-lg bg-solar-yellow px-4 py-2.5 text-sm font-semibold text-solar-dark hover:opacity-90 transition"
+                  >
+                    View SMS Payment Instructions
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* ── Online: SMS option as secondary CTA ── */}
+          {!isOffline && (
+            <div className="mb-5 flex items-center justify-between rounded-lg border border-white/10 bg-solar-accent px-4 py-3">
+              <span className="text-xs text-gray-400">Low connectivity? Use SMS instead.</span>
+              <button
+                onClick={() => setShowSmsModal(true)}
+                className="text-xs text-solar-yellow underline underline-offset-2 hover:opacity-80 transition"
+              >
+                SMS guide ↗
+              </button>
+            </div>
+          )}
 
           {!address ? (
             <div className="rounded-xl border border-white/10 bg-solar-accent p-8 text-center">
               <p className="text-gray-400 mb-4">Connect your wallet to make a payment.</p>
               <button
                 onClick={connect}
-                className="rounded-lg bg-solar-yellow px-6 py-2.5 font-semibold text-solar-dark hover:opacity-90 transition"
+                disabled={isOffline}
+                className="rounded-lg bg-solar-yellow px-6 py-2.5 font-semibold text-solar-dark hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition"
               >
                 Connect Wallet
               </button>
+              {isOffline && (
+                <p className="mt-2 text-xs text-gray-500">
+                  Wallet connection requires internet.
+                </p>
+              )}
             </div>
           ) : (
             <form
@@ -182,15 +243,40 @@ export default function PayPage() {
               {/* Submit */}
               <button
                 type="submit"
-                disabled={status === "loading"}
+                disabled={status === "loading" || isOffline}
                 className="w-full rounded-lg bg-solar-yellow py-3.5 text-base font-semibold text-solar-dark hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition"
               >
-                {status === "loading" ? "Waiting for wallet…" : "Pay Now"}
+                {isOffline
+                  ? "Unavailable offline"
+                  : status === "loading"
+                  ? "Waiting for wallet…"
+                  : "Pay Now"}
               </button>
+
+              {isOffline && (
+                <p className="text-center text-xs text-gray-500">
+                  No internet.{" "}
+                  <button
+                    type="button"
+                    onClick={() => setShowSmsModal(true)}
+                    className="text-solar-yellow underline underline-offset-2"
+                  >
+                    Use SMS payment instead.
+                  </button>
+                </p>
+              )}
             </form>
           )}
         </div>
       </main>
+
+      {/* ── SMS modal ── */}
+      {showSmsModal && (
+        <OfflinePaymentModal
+          meterId={meterId}
+          onClose={() => setShowSmsModal(false)}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/components/OfflinePaymentModal.tsx
+++ b/frontend/src/components/OfflinePaymentModal.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+
+const SMS_SHORTCODE = process.env.NEXT_PUBLIC_SMS_SHORTCODE ?? "20880";
+const SMS_WEBHOOK_DOCS =
+  process.env.NEXT_PUBLIC_SMS_WEBHOOK_DOCS ??
+  "https://github.com/damiedee96/Stellar-Solar-Grid/blob/main/backend/README.md";
+
+interface Props {
+  meterId?: string;
+  onClose: () => void;
+}
+
+const PLANS = [
+  { code: "D", label: "Daily" },
+  { code: "W", label: "Weekly" },
+  { code: "U", label: "Usage-Based" },
+];
+
+export default function OfflinePaymentModal({ meterId, onClose }: Props) {
+  const [copied, setCopied] = useState(false);
+  const exampleMeter = meterId?.trim() || "METER1";
+  const exampleSms = `PAY ${exampleMeter} 5 D`;
+
+  async function copyToClipboard(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable on some low-end browsers — silently ignore
+    }
+  }
+
+  return (
+    /* Backdrop */
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="offline-modal-title"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-4 pb-4 sm:pb-0"
+    >
+      {/* Dim overlay */}
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel — slides up from bottom on mobile */}
+      <div className="relative w-full max-w-md rounded-t-2xl sm:rounded-2xl bg-solar-accent border border-white/10 shadow-2xl overflow-hidden">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/10 bg-yellow-900/20">
+          <div className="flex items-center gap-2">
+            <span className="text-xl">📵</span>
+            <h2 id="offline-modal-title" className="font-bold text-solar-yellow text-base">
+              No Internet? Pay via SMS
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1.5 text-gray-400 hover:text-white hover:bg-white/10 transition"
+          >
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-5 py-5 space-y-5 max-h-[80vh] overflow-y-auto">
+
+          {/* Offline banner */}
+          <div className="flex items-center gap-2 rounded-lg border border-yellow-500/30 bg-yellow-900/20 px-3 py-2.5 text-xs text-yellow-300">
+            <span>⚠️</span>
+            <span>You appear to be offline. Use SMS to top up your meter without internet.</span>
+          </div>
+
+          {/* Step 1 */}
+          <section>
+            <h3 className="text-sm font-semibold text-white mb-2 flex items-center gap-1.5">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-solar-yellow text-solar-dark text-xs font-bold">1</span>
+              SMS Format
+            </h3>
+            <p className="text-xs text-gray-400 mb-2">
+              Send an SMS to <span className="text-solar-yellow font-bold">{SMS_SHORTCODE}</span> using this format:
+            </p>
+            <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-solar-dark px-4 py-3">
+              <code className="flex-1 text-sm text-solar-yellow font-mono tracking-wide">
+                PAY &lt;METER_ID&gt; &lt;AMOUNT&gt; &lt;PLAN&gt;
+              </code>
+            </div>
+          </section>
+
+          {/* Example */}
+          <section>
+            <h3 className="text-sm font-semibold text-white mb-2 flex items-center gap-1.5">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-solar-yellow text-solar-dark text-xs font-bold">2</span>
+              Example
+            </h3>
+            <div className="flex items-center gap-2 rounded-lg border border-solar-yellow/30 bg-solar-yellow/5 px-4 py-3">
+              <code className="flex-1 text-sm text-white font-mono">{exampleSms}</code>
+              <button
+                onClick={() => copyToClipboard(exampleSms)}
+                aria-label="Copy SMS example"
+                className="shrink-0 rounded-md border border-white/10 px-2.5 py-1 text-xs text-gray-300 hover:border-solar-yellow hover:text-solar-yellow transition"
+              >
+                {copied ? "✓ Copied" : "Copy"}
+              </button>
+            </div>
+            <p className="mt-1.5 text-xs text-gray-500">
+              Send to: <span className="text-solar-yellow font-bold">{SMS_SHORTCODE}</span>
+            </p>
+          </section>
+
+          {/* Plan codes */}
+          <section>
+            <h3 className="text-sm font-semibold text-white mb-2 flex items-center gap-1.5">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-solar-yellow text-solar-dark text-xs font-bold">3</span>
+              Plan Codes
+            </h3>
+            <div className="grid grid-cols-3 gap-2">
+              {PLANS.map((p) => (
+                <div
+                  key={p.code}
+                  className="rounded-lg border border-white/10 bg-solar-dark px-3 py-2.5 text-center"
+                >
+                  <div className="text-solar-yellow font-bold font-mono text-base">{p.code}</div>
+                  <div className="text-xs text-gray-400 mt-0.5">{p.label}</div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* What happens next */}
+          <section className="rounded-lg border border-white/10 bg-solar-dark px-4 py-3 text-xs text-gray-400 space-y-1">
+            <p className="font-semibold text-gray-300 mb-1">What happens next?</p>
+            <p>✓ You'll receive a confirmation SMS within 60 seconds.</p>
+            <p>✓ Your meter will be topped up automatically.</p>
+            <p>✓ Transaction is recorded on the Stellar blockchain.</p>
+          </section>
+
+          {/* Docs link */}
+          <a
+            href={SMS_WEBHOOK_DOCS}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-1.5 text-xs text-blue-400 underline underline-offset-2 hover:text-blue-300 transition py-1"
+          >
+            📄 View SMS webhook documentation ↗
+          </a>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-4 border-t border-white/10">
+          <button
+            onClick={onClose}
+            className="w-full rounded-lg border border-white/10 py-3 text-sm text-gray-300 hover:border-solar-yellow hover:text-solar-yellow transition"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOffline.ts
+++ b/frontend/src/hooks/useOffline.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns true when the browser reports no network connectivity.
+ * Listens to the window online/offline events so the value stays
+ * in sync without polling.
+ */
+export function useOffline(): boolean {
+  // navigator.onLine can be undefined in SSR — default to false (online)
+  const [isOffline, setIsOffline] = useState<boolean>(false);
+
+  useEffect(() => {
+    // Set initial state from browser API
+    setIsOffline(!navigator.onLine);
+
+    function goOffline() { setIsOffline(true); }
+    function goOnline()  { setIsOffline(false); }
+
+    window.addEventListener("offline", goOffline);
+    window.addEventListener("online",  goOnline);
+
+    return () => {
+      window.removeEventListener("offline", goOffline);
+      window.removeEventListener("online",  goOnline);
+    };
+  }, []);
+
+  return isOffline;
+}


### PR DESCRIPTION
feat(frontend): add offline/SMS payment fallback UI

Closes #26

Summary
Users in low-connectivity rural areas can now pay via SMS when they have no internet. The UI detects offline status in real time and surfaces clear instructions without requiring any data connection.

Changes
useOffline.ts
Detects navigator.onLine on mount and subscribes to window online/offline events
SSR-safe (defaults to false until hydrated)
Cleans up event listeners on unmount
OfflinePaymentModal.tsx
Full-screen bottom-sheet modal (slides up on mobile, centered on desktop)
Step-by-step SMS format: PAY <METER_ID> <AMOUNT> <PLAN>
SMS shortcode pulled from NEXT_PUBLIC_SMS_SHORTCODE
Plan code reference table: D = Daily, W = Weekly, U = Usage-Based
Copy-to-clipboard button for the example SMS string
Pre-fills meter ID from the form if already entered
Link to backend SMS webhook docs (NEXT_PUBLIC_SMS_WEBHOOK_DOCS)
Accessible: role="dialog", aria-modal, aria-labelledby, close button with aria-label
page.tsx
Yellow offline banner at top of page with "Pay via SMS" CTA
Offline card replaces the connect/form area with SMS instructions shortcut
"Pay Now" button disabled and labelled "Unavailable offline"
"Connect Wallet" disabled with explanation when offline
SMS guide link shown as a secondary CTA even when online
.env.example / .env.local
Added NEXT_PUBLIC_SMS_SHORTCODE=20880
Added NEXT_PUBLIC_SMS_WEBHOOK_DOCS=<url>
Testing
Open /pay in Chrome DevTools → Network tab → set to Offline
Confirm yellow banner appears with "Pay via SMS" button
Confirm "Pay Now" is disabled and labelled correctly
Click "Pay via SMS" — modal opens with correct shortcode and format
Enter a meter ID in the form, reopen modal — confirm it pre-fills in the example
Click Copy — confirm clipboard contains the SMS string
Set network back to Online — confirm banner disappears, form re-enables