### PR TITLE
feat: add toasts, request validation, and typed contract errors

### DIFF
--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -13,11 +13,12 @@ import { adminInvoke } from "../lib/stellar.js";
 import { logger } from "../lib/logger.js";
 import { mqttMessages } from "../lib/metrics.js";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { adminInvoke, CONTRACT_ID, server } from "../lib/stellar.js";
+import { CONTRACT_ID, server } from "../lib/stellar.js";
 
 const BROKER = process.env.MQTT_BROKER ?? "mqtt://localhost:1883";
 const TOPIC = "solargrid/meters/+/usage";
 const FLUSH_INTERVAL_MS = Number(process.env.BATCH_FLUSH_MS ?? 5_000);
+const EVENT_POLL_INTERVAL_MS = Number(process.env.EVENT_POLL_INTERVAL_MS ?? 5_000);
 
 interface Reading {
   meterId: string;
@@ -133,13 +134,10 @@ async function pollContractEvents() {
 }
 
 async function handleContractEvent(
-  event: StellarSdk.SorobanRpc.Api.RawEventResponse,
+  event: StellarSdk.SorobanRpc.Api.EventResponse,
 ) {
   try {
-    // Topics are XDR-encoded ScVals — first topic is the event name tuple
-    const topics = event.topic.map((t) =>
-      StellarSdk.xdr.ScVal.fromXDR(t, "base64"),
-    );
+    const topics = event.topic;
 
     if (topics.length < 2) return;
 
@@ -152,7 +150,7 @@ async function handleContractEvent(
 
     switch (eventKey) {
       case "payment:received": {
-        const data = StellarSdk.xdr.ScVal.fromXDR(event.value, "base64");
+        const data = event.value;
         const native = StellarSdk.scValToNative(data) as [string, bigint, unknown];
         const [meterId, amount] = native;
         console.log(
@@ -163,7 +161,7 @@ async function handleContractEvent(
       }
 
       case "meter:activated": {
-        const data = StellarSdk.xdr.ScVal.fromXDR(event.value, "base64");
+        const data = event.value;
         const meterId = String(StellarSdk.scValToNative(data));
         console.log(`✅ meter_activated — meter: ${meterId}`);
         await onMeterActivated(meterId);
@@ -171,7 +169,7 @@ async function handleContractEvent(
       }
 
       case "meter:deactivated": {
-        const data = StellarSdk.xdr.ScVal.fromXDR(event.value, "base64");
+        const data = event.value;
         const meterId = String(StellarSdk.scValToNative(data));
         console.log(`🔴 meter_deactivated — meter: ${meterId}`);
         await onMeterDeactivated(meterId);

--- a/backend/src/lib/validation.ts
+++ b/backend/src/lib/validation.ts
@@ -1,23 +1,120 @@
-import { z } from "zod";
+import type { RequestHandler } from "express";
+import { z, type ZodTypeAny } from "zod";
 
-const STELLAR_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
+const STELLAR_ACCOUNT_REGEX = /^G[A-Z2-7]{55}$/;
+const STELLAR_ADDRESS_REGEX = /^[GC][A-Z2-7]{55}$/;
 
-export const RegisterMeterSchema = z.object({
-  meter_id: z.string().min(1, "meter_id is required").max(32, "meter_id must be at most 32 characters"),
-  owner: z.string().regex(STELLAR_ADDRESS_REGEX, "Invalid Stellar address format"),
-});
+const MeterIdSchema = z
+  .string()
+  .trim()
+  .min(1, "meter_id is required")
+  .max(12, "meter_id must be at most 12 characters");
 
-export const UsageUpdateSchema = z.object({
-  units: z.number().int("units must be an integer").positive("units must be positive"),
-  cost: z.number().int("cost must be an integer").positive("cost must be positive"),
-});
+const MeterRouteParamsSchema = z
+  .object({
+    id: MeterIdSchema,
+  })
+  .strict();
 
-export const MakePaymentSchema = z.object({
-  token_address: z.string().regex(STELLAR_ADDRESS_REGEX, "Invalid token_address format"),
-  payer: z.string().regex(STELLAR_ADDRESS_REGEX, "Invalid payer address format"),
-  amount_stroops: z.number().int("amount_stroops must be an integer").positive("amount_stroops must be positive"),
-  plan: z.string().min(1, "plan is required"),
-});
+const PaymentPlanSchema = z.enum(["Daily", "Weekly", "Usage", "UsageBased"]);
+
+export const RegisterMeterSchema = z
+  .object({
+    meter_id: MeterIdSchema,
+    owner: z
+      .string()
+      .regex(STELLAR_ACCOUNT_REGEX, "Invalid Stellar account address format"),
+  })
+  .strict();
+
+export const UsageUpdateSchema = z
+  .object({
+    units: z
+      .number()
+      .int("units must be an integer")
+      .positive("units must be positive"),
+    cost: z
+      .number()
+      .int("cost must be an integer")
+      .positive("cost must be positive"),
+  })
+  .strict();
+
+export const MakePaymentSchema = z
+  .object({
+    token_address: z
+      .string()
+      .regex(STELLAR_ADDRESS_REGEX, "Invalid token_address format"),
+    payer: z
+      .string()
+      .regex(STELLAR_ACCOUNT_REGEX, "Invalid payer address format"),
+    amount_stroops: z
+      .number()
+      .int("amount_stroops must be an integer")
+      .positive("amount_stroops must be positive"),
+    plan: PaymentPlanSchema,
+  })
+  .strict();
+
+export const SmsPaymentWebhookSchema = z
+  .object({
+    meter_id: MeterIdSchema,
+    amount_xlm: z
+      .number()
+      .positive("amount_xlm must be positive")
+      .finite("amount_xlm must be a finite number"),
+  })
+  .strict();
+
+type RequestSchemaSet = {
+  body?: ZodTypeAny;
+  params?: ZodTypeAny;
+  query?: ZodTypeAny;
+};
+
+export function validateRequest(schemas: RequestSchemaSet): RequestHandler {
+  return (req, res, next) => {
+    const details: Record<string, unknown> = {};
+
+    if (schemas.body) {
+      const parsed = schemas.body.safeParse(req.body);
+      if (!parsed.success) {
+        details.body = parsed.error.flatten().fieldErrors;
+      } else {
+        req.body = parsed.data as typeof req.body;
+      }
+    }
+
+    if (schemas.params) {
+      const parsed = schemas.params.safeParse(req.params);
+      if (!parsed.success) {
+        details.params = parsed.error.flatten().fieldErrors;
+      } else {
+        req.params = parsed.data as typeof req.params;
+      }
+    }
+
+    if (schemas.query) {
+      const parsed = schemas.query.safeParse(req.query);
+      if (!parsed.success) {
+        details.query = parsed.error.flatten().fieldErrors;
+      } else {
+        req.query = parsed.data as typeof req.query;
+      }
+    }
+
+    if (Object.keys(details).length > 0) {
+      return res.status(400).json({
+        error: "Validation failed",
+        details,
+      });
+    }
+
+    next();
+  };
+}
+
+export { MeterRouteParamsSchema };
 
 export type RegisterMeterInput = z.infer<typeof RegisterMeterSchema>;
 export type UsageUpdateInput = z.infer<typeof UsageUpdateSchema>;

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -3,7 +3,13 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import { adminInvoke, contractQuery } from "../lib/stellar.js";
 import { activeMeters, paymentVolume } from "../lib/metrics.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
-import { RegisterMeterSchema, UsageUpdateSchema, MakePaymentSchema } from "../lib/validation.js";
+import {
+  MakePaymentSchema,
+  MeterRouteParamsSchema,
+  RegisterMeterSchema,
+  UsageUpdateSchema,
+  validateRequest,
+} from "../lib/validation.js";
 
 export const meterRouter = Router();
 
@@ -43,16 +49,9 @@ meterRouter.get(
 /** POST /api/meters — register a new meter (admin only) */
 meterRouter.post(
   "/",
+  validateRequest({ body: RegisterMeterSchema }),
   asyncHandler(async (req, res) => {
-    const validation = RegisterMeterSchema.safeParse(req.body);
-    if (!validation.success) {
-      return res.status(400).json({
-        error: "Validation failed",
-        details: validation.error.flatten().fieldErrors,
-      });
-    }
-
-    const { meter_id, owner } = validation.data;
+    const { meter_id, owner } = req.body;
 
     const hash = await adminInvoke("register_meter", [
       StellarSdk.nativeToScVal(meter_id, { type: "symbol" }),
@@ -65,16 +64,9 @@ meterRouter.post(
 /** POST /api/meters/:id/usage — IoT oracle reports usage */
 meterRouter.post(
   "/:id/usage",
+  validateRequest({ params: MeterRouteParamsSchema, body: UsageUpdateSchema }),
   asyncHandler(async (req, res) => {
-    const validation = UsageUpdateSchema.safeParse(req.body);
-    if (!validation.success) {
-      return res.status(400).json({
-        error: "Validation failed",
-        details: validation.error.flatten().fieldErrors,
-      });
-    }
-
-    const { units, cost } = validation.data;
+    const { units, cost } = req.body;
 
     const hash = await adminInvoke("update_usage", [
       StellarSdk.nativeToScVal(req.params.id, { type: "symbol" }),
@@ -96,25 +88,17 @@ const idempotencyCache = new Map<string, { hash: string; timestamp: number }>();
  * Body: { token_address, payer, amount_stroops, plan }
  * Header: Idempotency-Key: <uuid>  (optional — duplicate within 24 h returns cached txHash)
  */
-meterRouter.post("/:id/pay", asyncHandler(async (req, res) => {
-  const validation = MakePaymentSchema.safeParse(req.body);
-  if (!validation.success) {
-    return res.status(400).json({
-      error: "Validation failed",
-      details: validation.error.flatten().fieldErrors,
-    });
-  }
-
+meterRouter.post("/:id/pay", validateRequest({ params: MeterRouteParamsSchema, body: MakePaymentSchema }), asyncHandler(async (req, res) => {
   const ikey = req.headers["idempotency-key"] as string | undefined;
 
-    if (ikey) {
-      const cached = idempotencyCache.get(ikey);
-      if (cached && Date.now() - cached.timestamp < TTL_MS) {
-        return res.json({ hash: cached.hash });
-      }
+  if (ikey) {
+    const cached = idempotencyCache.get(ikey);
+    if (cached && Date.now() - cached.timestamp < TTL_MS) {
+      return res.json({ hash: cached.hash });
     }
+  }
 
-  const { token_address, payer, amount_stroops, plan } = validation.data;
+  const { token_address, payer, amount_stroops, plan } = req.body;
 
   const hash = await adminInvoke("make_payment", [
     StellarSdk.nativeToScVal(req.params.id, { type: "symbol" }),

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -4,6 +4,7 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import { adminInvoke } from "../lib/stellar.js";
 import { activeMeters, paymentVolume } from "../lib/metrics.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
+import { SmsPaymentWebhookSchema, validateRequest } from "../lib/validation.js";
 
 export const webhookRouter = Router();
 
@@ -30,6 +31,7 @@ function verifySignature(rawBody: Buffer, signature: string): boolean {
  */
 webhookRouter.post(
   "/sms-payment",
+  validateRequest({ body: SmsPaymentWebhookSchema }),
   asyncHandler(async (req, res) => {
     const signature = req.headers["x-webhook-signature"] as string | undefined;
     if (
@@ -42,28 +44,7 @@ webhookRouter.post(
       return res.status(401).json({ error: "Invalid webhook signature" });
     }
 
-    if (!req.body || typeof req.body !== "object") {
-      return res
-        .status(400)
-        .json({ error: "Request body must be a JSON object" });
-    }
-
-    const { meter_id, amount_xlm } = req.body as {
-      meter_id?: unknown;
-      amount_xlm?: unknown;
-    };
-
-    if (
-      typeof meter_id !== "string" ||
-      meter_id.trim().length === 0 ||
-      typeof amount_xlm !== "number" ||
-      !Number.isFinite(amount_xlm) ||
-      amount_xlm <= 0
-    ) {
-      return res
-        .status(400)
-        .json({ error: "meter_id and positive amount_xlm are required" });
-    }
+    const { meter_id, amount_xlm } = req.body;
 
     const stroops = BigInt(Math.round(amount_xlm * 10_000_000));
     const hash = await adminInvoke("make_payment", [

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -7,12 +7,19 @@ use soroban_sdk::{
 // ── Error types ───────────────────────────────────────────────────────────────
 
 #[contracterror]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ContractError {
-    NotInitialized    = 1,
-    MeterAlreadyExists = 2,
-    OracleNotSet      = 3,
-    UnauthorizedOracle = 4,
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    MeterNotFound = 3,
+    MeterAlreadyExists = 4,
+    Unauthorized = 5,
+    InvalidAmount = 6,
+    OwnerNotAllowlisted = 7,
+    OracleNotSet = 8,
+    InsufficientProviderRevenue = 9,
+    BatchTooLarge = 10,
+    CannotActivateWithoutBalance = 11,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -94,13 +101,14 @@ pub struct SolarGridContract;
 #[contractimpl]
 impl SolarGridContract {
     /// Initialize the contract with an admin address and the SAC token address.
-    pub fn initialize(env: Env, admin: Address, token_address: Address) {
-        env.deployer().require_auth();
+    pub fn initialize(env: Env, admin: Address, token_address: Address) -> Result<(), ContractError> {
+        admin.require_auth();
         if env.storage().instance().has(&ADMIN) {
-            panic!("already initialized");
+            return Err(ContractError::AlreadyInitialized);
         }
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&TOKEN, &token_address);
+        Ok(())
     }
 
     /// Register a new smart meter for an owner.
@@ -113,15 +121,15 @@ impl SolarGridContract {
     ///   could cause downstream auth issues.
     /// - `owner` must co-sign the registration (require_auth), confirming they
     ///   consent to being the meter owner.
-    pub fn register_meter(env: Env, meter_id: Symbol, owner: Address) {
-        Self::require_admin(&env);
-        let allowlist = Self::get_allowlist(env.clone());
+    pub fn register_meter(env: Env, meter_id: Symbol, owner: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        let allowlist = Self::get_allowlist(env.clone())?;
         if !allowlist.contains(&owner) {
-            panic!("owner not in allowlist");
+            return Err(ContractError::OwnerNotAllowlisted);
         }
         let key = DataKey::Meter(meter_id.clone());
         if env.storage().persistent().has(&key) {
-            env.panic_with_error(ContractError::MeterAlreadyExists);
+            return Err(ContractError::MeterAlreadyExists);
         }
         let meter = Meter {
             version: 1,
@@ -149,22 +157,23 @@ impl SolarGridContract {
             (symbol_short!("mtr_reg"), EVT_NS, meter_id),
             owner,
         );
+        Ok(())
     }
 
     /// Get all meter IDs registered under a given owner address.
-    pub fn get_meters_by_owner(env: Env, owner: Address) -> Vec<Symbol> {
+    pub fn get_meters_by_owner(env: Env, owner: Address) -> Result<Vec<Symbol>, ContractError> {
         let owner_key = DataKey::OwnerMeters(owner);
-        env.storage()
+        Ok(env.storage()
             .persistent()
             .get(&owner_key)
-            .unwrap_or_else(|| vec![&env])
+            .unwrap_or_else(|| vec![&env]))
     }
 
     /// Add an address to the meter-owner allowlist.
     /// Only the admin may call this. Use this to pre-approve user accounts
     /// (G… addresses) before they can be registered as meter owners.
-    pub fn allowlist_add(env: Env, owner: Address) {
-        Self::require_admin(&env);
+    pub fn allowlist_add(env: Env, owner: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let mut list: Vec<Address> = env
             .storage()
             .instance()
@@ -174,12 +183,13 @@ impl SolarGridContract {
             list.push_back(owner);
             env.storage().instance().set(&ALLOWLIST, &list);
         }
+        Ok(())
     }
 
     /// Remove an address from the meter-owner allowlist.
     /// Only the admin may call this.
-    pub fn allowlist_remove(env: Env, owner: Address) {
-        Self::require_admin(&env);
+    pub fn allowlist_remove(env: Env, owner: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let list: Vec<Address> = env
             .storage()
             .instance()
@@ -192,25 +202,28 @@ impl SolarGridContract {
             }
         }
         env.storage().instance().set(&ALLOWLIST, &new_list);
+        Ok(())
     }
 
     /// Returns the current allowlist.
-    pub fn get_allowlist(env: Env) -> Vec<Address> {
-        env.storage()
+    pub fn get_allowlist(env: Env) -> Result<Vec<Address>, ContractError> {
+        Ok(env.storage()
             .instance()
             .get(&ALLOWLIST)
-            .unwrap_or(Vec::new(&env))
+            .unwrap_or(Vec::new(&env)))
     }
 
     /// Register the IoT oracle address. Only admin may call this.
-    pub fn set_oracle(env: Env, oracle: Address) {
-        Self::require_admin(&env);
+    pub fn set_oracle(env: Env, oracle: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         env.storage().instance().set(&ORACLE, &oracle);
+        Ok(())
     }
 
     /// Return the registered oracle address, if any.
-    pub fn get_oracle(env: Env) -> Option<Address> {
-        env.storage().instance().get(&ORACLE)
+    pub fn get_oracle(env: Env) -> Result<Option<Address>, ContractError> {
+        Self::require_initialized(&env)?;
+        Ok(env.storage().instance().get(&ORACLE))
     }
 
     /// Make a payment to top up a meter's balance and activate it.
@@ -225,21 +238,19 @@ impl SolarGridContract {
         payer: Address,
         amount: i128,
         plan: PaymentPlan,
-    ) {
+    ) -> Result<(), ContractError> {
+        Self::require_initialized(&env)?;
         payer.require_auth();
         if amount <= 0 {
-            panic!("amount must be positive");
+            return Err(ContractError::InvalidAmount);
         }
-        let token_address: Address = env.storage().instance().get(&TOKEN).expect("not initialized");
+        let token_address = Self::get_token_address(&env)?;
         let token_client = token::Client::new(&env, &token_address);
         token_client.transfer(&payer, &env.current_contract_address(), &amount);
 
         let key = DataKey::Meter(meter_id.clone());
-        let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
+        let mut meter = Self::get_meter_by_id(&env, &meter_id)?;
         let now = env.ledger().timestamp();
-        match plan {
-            PaymentPlan::Daily | PaymentPlan::Weekly | PaymentPlan::UsageBased => {}
-        }
         let expires_at = match plan {
             PaymentPlan::Daily => now.saturating_add(SECONDS_PER_DAY),
             PaymentPlan::Weekly => now.saturating_add(SECONDS_PER_WEEK),
@@ -258,7 +269,7 @@ impl SolarGridContract {
         env.storage().persistent().set(&key, &meter);
 
         // Track provider (admin) accrued revenue
-        let admin: Address = env.storage().instance().get(&ADMIN).expect("not initialized");
+        let admin = Self::get_admin(&env)?;
         let provider_key = DataKey::ProviderRevenue(admin);
         let provider_revenue: i128 = env.storage().persistent().get(&provider_key).unwrap_or(0);
         env.storage()
@@ -275,6 +286,7 @@ impl SolarGridContract {
             (symbol_short!("mtr_actv"), EVT_NS, meter_id),
             (),
         );
+        Ok(())
     }
 
     /// Withdraw accumulated revenue from the contract vault to the provider address.
@@ -288,28 +300,28 @@ impl SolarGridContract {
     /// - `"insufficient provider revenue"` — if tracked balance < `amount`
     ///
     /// Emits: `rev_wdrl { provider, token_address, amount }`
-    pub fn withdraw_revenue(env: Env, provider: Address, amount: i128) {
+    pub fn withdraw_revenue(env: Env, provider: Address, amount: i128) -> Result<(), ContractError> {
         if amount <= 0 {
-            panic!("amount must be positive");
+            return Err(ContractError::InvalidAmount);
         }
-        Self::require_initialized(&env);
-        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        Self::require_initialized(&env)?;
+        let admin = Self::get_admin(&env)?;
         if provider != admin {
-            panic!("provider is not admin");
+            return Err(ContractError::Unauthorized);
         }
         provider.require_auth();
 
         let provider_key = DataKey::ProviderRevenue(provider.clone());
         let provider_revenue: i128 = env.storage().persistent().get(&provider_key).unwrap_or(0);
         if provider_revenue < amount {
-            panic!("insufficient provider revenue");
+            return Err(ContractError::InsufficientProviderRevenue);
         }
 
         env.storage()
             .persistent()
             .set(&provider_key, &(provider_revenue - amount));
 
-        let token_address: Address = env.storage().instance().get(&TOKEN).expect("not initialized");
+        let token_address = Self::get_token_address(&env)?;
         let token_client = token::Client::new(&env, &token_address);
         token_client.transfer(&env.current_contract_address(), &provider, &amount);
 
@@ -317,21 +329,22 @@ impl SolarGridContract {
             (symbol_short!("rev_wdrl"), EVT_NS, provider),
             (token_address, amount),
         );
+        Ok(())
     }
 
     /// Get currently tracked provider revenue balance.
-    pub fn get_provider_revenue(env: Env, provider: Address) -> i128 {
+    pub fn get_provider_revenue(env: Env, provider: Address) -> Result<i128, ContractError> {
+        Self::require_initialized(&env)?;
         let provider_key = DataKey::ProviderRevenue(provider);
-        env.storage().persistent().get(&provider_key).unwrap_or(0)
+        Ok(env.storage().persistent().get(&provider_key).unwrap_or(0))
     }
 
     /// Check whether a meter currently has active energy access.
-    pub fn check_access(env: Env, meter_id: Symbol) -> bool {
-        let key = DataKey::Meter(meter_id.clone());
-        let meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
+    pub fn check_access(env: Env, meter_id: Symbol) -> Result<bool, ContractError> {
+        let meter = Self::get_meter_by_id(&env, &meter_id)?;
         let bal_key = DataKey::MeterBalance(meter_id);
         let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-        meter.active && balance > 0 && env.ledger().timestamp() < meter.expires_at
+        Ok(meter.active && balance > 0 && env.ledger().timestamp() < meter.expires_at)
     }
 
     /// Called by the IoT oracle to record energy consumption (milli-kWh).
@@ -340,10 +353,13 @@ impl SolarGridContract {
     /// Emits:
     /// - `usage_updated    { meter_id, units, cost }`
     /// - `meter_deactivated { meter_id }` (only when balance hits zero)
-    pub fn update_usage(env: Env, meter_id: Symbol, units: u64, cost: i128) {
-        Self::require_oracle(&env);
+    pub fn update_usage(env: Env, meter_id: Symbol, units: u64, cost: i128) -> Result<(), ContractError> {
+        Self::require_oracle(&env)?;
+        if cost < 0 {
+            return Err(ContractError::InvalidAmount);
+        }
         let key = DataKey::Meter(meter_id.clone());
-        let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
+        let mut meter = Self::get_meter_by_id(&env, &meter_id)?;
         let bal_key = DataKey::MeterBalance(meter_id.clone());
         let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
         let new_balance = balance.checked_sub(cost).unwrap_or(0).max(0);
@@ -369,6 +385,7 @@ impl SolarGridContract {
                 (),
             );
         }
+        Ok(())
     }
 
     /// Batch update usage for multiple meters in a single transaction.
@@ -380,12 +397,15 @@ impl SolarGridContract {
     ///
     /// Emits per skipped meter:
     /// - `batch_skip { meter_id }`
-    pub fn batch_update_usage(env: Env, updates: Vec<(Symbol, u64, i128)>) {
-        Self::require_oracle(&env);
+    pub fn batch_update_usage(env: Env, updates: Vec<(Symbol, u64, i128)>) -> Result<(), ContractError> {
+        Self::require_oracle(&env)?;
         if updates.len() > 50 {
-            panic!("batch too large");
+            return Err(ContractError::BatchTooLarge);
         }
         for (meter_id, units, cost) in updates.iter() {
+            if cost < 0 {
+                return Err(ContractError::InvalidAmount);
+            }
             let key = DataKey::Meter(meter_id.clone());
             let meter_opt: Option<Meter> = env.storage().persistent().get(&key);
             let mut meter = match meter_opt {
@@ -421,18 +441,25 @@ impl SolarGridContract {
                 );
             }
         }
+        Ok(())
     }
 
     /// Get the on-chain token balance held by this contract for a specific meter.
-    pub fn get_meter_balance(env: Env, meter_id: Symbol) -> i128 {
+    pub fn get_meter_balance(env: Env, meter_id: Symbol) -> Result<i128, ContractError> {
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::Meter(meter_id.clone()))
+        {
+            return Err(ContractError::MeterNotFound);
+        }
         let bal_key = DataKey::MeterBalance(meter_id);
-        env.storage().persistent().get(&bal_key).unwrap_or(0)
+        Ok(env.storage().persistent().get(&bal_key).unwrap_or(0))
     }
 
     /// Get meter details.
-    pub fn get_meter(env: Env, meter_id: Symbol) -> Meter {
-        let key = DataKey::Meter(meter_id);
-        env.storage().persistent().get(&key).expect("meter not found")
+    pub fn get_meter(env: Env, meter_id: Symbol) -> Result<Meter, ContractError> {
+        Self::get_meter_by_id(&env, &meter_id)
     }
 
     /// Admin can manually toggle meter access (e.g. maintenance).
@@ -444,15 +471,15 @@ impl SolarGridContract {
     /// Emits:
     /// - `meter_activated   { meter_id }` when toggled on
     /// - `meter_deactivated { meter_id }` when toggled off
-    pub fn set_active(env: Env, meter_id: Symbol, active: bool) {
-        Self::require_admin(&env);
+    pub fn set_active(env: Env, meter_id: Symbol, active: bool) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let key = DataKey::Meter(meter_id.clone());
-        let mut meter: Meter = env.storage().persistent().get(&key).expect("meter not found");
+        let mut meter = Self::get_meter_by_id(&env, &meter_id)?;
         if active {
             let bal_key = DataKey::MeterBalance(meter_id.clone());
             let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
             if balance == 0 {
-                panic!("cannot activate meter with zero balance");
+                return Err(ContractError::CannotActivateWithoutBalance);
             }
         }
         meter.active = active;
@@ -469,6 +496,7 @@ impl SolarGridContract {
                 (),
             );
         }
+        Ok(())
     }
 
     /// Migrate a single meter entry from the v0 (LegacyMeter) schema to v1 (Meter).
@@ -477,41 +505,66 @@ impl SolarGridContract {
     /// # Panics
     /// - `ContractError::NotInitialized` — if contract is not initialized
     /// - `"meter not found"` — if `meter_id` has no storage entry
-    pub fn migrate_meter(env: Env, meter_id: Symbol) {
-        Self::require_admin(&env);
+    pub fn migrate_meter(env: Env, meter_id: Symbol) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         let key = DataKey::Meter(meter_id.clone());
-        // Attempt to read as current Meter first; if it deserializes, already migrated.
         let legacy: LegacyMeter = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("meter not found");
+            .ok_or(ContractError::MeterNotFound)?;
         let migrated = migrate_meter_v0(legacy);
         env.storage().persistent().set(&key, &migrated);
+        Ok(())
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────
 
-    fn require_initialized(env: &Env) {
+    fn require_initialized(env: &Env) -> Result<(), ContractError> {
         if !env.storage().instance().has(&ADMIN) {
-            env.panic_with_error(ContractError::NotInitialized);
+            return Err(ContractError::NotInitialized);
         }
+        Ok(())
     }
 
-    fn require_admin(env: &Env) {
-        Self::require_initialized(env);
-        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+    fn require_admin(env: &Env) -> Result<(), ContractError> {
+        let admin = Self::get_admin(env)?;
         admin.require_auth();
+        Ok(())
     }
 
-    fn require_oracle(env: &Env) {
-        Self::require_initialized(env);
+    fn require_oracle(env: &Env) -> Result<(), ContractError> {
+        Self::require_initialized(env)?;
         let oracle: Address = env
             .storage()
             .instance()
             .get(&ORACLE)
-            .unwrap_or_else(|| env.panic_with_error(ContractError::OracleNotSet));
+            .ok_or(ContractError::OracleNotSet)?;
         oracle.require_auth();
+        Ok(())
+    }
+
+    fn get_admin(env: &Env) -> Result<Address, ContractError> {
+        Self::require_initialized(env)?;
+        env.storage()
+            .instance()
+            .get(&ADMIN)
+            .ok_or(ContractError::NotInitialized)
+    }
+
+    fn get_token_address(env: &Env) -> Result<Address, ContractError> {
+        Self::require_initialized(env)?;
+        env.storage()
+            .instance()
+            .get(&TOKEN)
+            .ok_or(ContractError::NotInitialized)
+    }
+
+    fn get_meter_by_id(env: &Env, meter_id: &Symbol) -> Result<Meter, ContractError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Meter(meter_id.clone()))
+            .ok_or(ContractError::MeterNotFound)
     }
 }
 
@@ -552,16 +605,6 @@ mod tests {
     ) {
         client.allowlist_add(user);
         client.register_meter(meter_id, user);
-    }
-
-    fn setup_token(env: &Env) -> (Address, token::StellarAssetClient<'_>, token::Client<'_>) {
-        let token_admin = Address::generate(env);
-        let token_address = env
-            .register_stellar_asset_contract_v2(token_admin.clone())
-            .address();
-        let token_admin_client = token::StellarAssetClient::new(env, &token_address);
-        let token_client = token::Client::new(env, &token_address);
-        (token_address, token_admin_client, token_client)
     }
 
     /// Setup with a specific token registered in initialize.
@@ -624,25 +667,25 @@ mod tests {
         );
     }
 
-    /// make_payment with amount = 0 should panic.
+    /// make_payment with amount = 0 should return InvalidAmount.
     #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn test_make_payment_zero_amount_panics() {
+    fn test_make_payment_zero_amount_returns_invalid_amount() {
         let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER3");
         allowlist_and_register(&client, &meter_id, &user);
-        client.make_payment(&meter_id, &user, &0_i128, &PaymentPlan::Daily);
+        let result = client.try_make_payment(&meter_id, &user, &0_i128, &PaymentPlan::Daily);
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
     }
 
     #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn test_make_payment_negative_amount_panics() {
+    fn test_make_payment_negative_amount_returns_invalid_amount() {
         let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER4");
         allowlist_and_register(&client, &meter_id, &user);
-        client.make_payment(&meter_id, &user, &-1_i128, &PaymentPlan::Daily);
+        let result = client.try_make_payment(&meter_id, &user, &-1_i128, &PaymentPlan::Daily);
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
     }
 
     #[test]
@@ -794,15 +837,14 @@ mod tests {
         assert!(renewed.expires_at > meter.expires_at);
     }
 
-    /// Registering an owner not on the allowlist must panic.
+    /// Registering an owner not on the allowlist must return OwnerNotAllowlisted.
     #[test]
-    #[should_panic(expected = "owner not in allowlist")]
-    fn test_register_meter_owner_not_allowlisted_panics() {
+    fn test_register_meter_owner_not_allowlisted_returns_typed_error() {
         let (env, client, _admin) = setup();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METER8");
-        // Deliberately skip allowlist_add
-        client.register_meter(&meter_id, &user);
+        let result = client.try_register_meter(&meter_id, &user);
+        assert_eq!(result, Err(Ok(ContractError::OwnerNotAllowlisted)));
     }
 
     /// allowlist_add / allowlist_remove round-trip.
@@ -867,13 +909,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "insufficient provider revenue")]
-    fn test_withdraw_revenue_panics_when_amount_exceeds_tracked_balance() {
+    fn test_withdraw_revenue_returns_insufficient_provider_revenue() {
         let (env, client, admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("METR10");
         allowlist_and_register(&client, &meter_id, &user);
-        client.withdraw_revenue(&admin, &1_i128);
+        let result = client.try_withdraw_revenue(&admin, &1_i128);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientProviderRevenue)));
     }
 
     #[test]
@@ -896,15 +938,15 @@ mod tests {
 
     // ── Event emission tests ──────────────────────────────────────────────────
 
-    /// set_active(true) must panic when the meter has zero balance (#86).
+    /// set_active(true) must return CannotActivateWithoutBalance when the meter has zero balance.
     #[test]
-    #[should_panic(expected = "cannot activate meter with zero balance")]
-    fn test_set_active_true_panics_when_balance_zero() {
+    fn test_set_active_true_returns_cannot_activate_without_balance() {
         let (env, client, _admin, _token_address) = setup_with_token();
         let user = Address::generate(&env);
         let meter_id = symbol_short!("ZERO_BAL");
         allowlist_and_register(&client, &meter_id, &user);
-        client.set_active(&meter_id, &true);
+        let result = client.try_set_active(&meter_id, &true);
+        assert_eq!(result, Err(Ok(ContractError::CannotActivateWithoutBalance)));
     }
 
     #[test]
@@ -1228,10 +1270,42 @@ mod tests {
         env.mock_all_auths();
         let contract_id = env.register_contract(None, SolarGridContract);
         let client = SolarGridContractClient::new(&env, &contract_id);
-        let user = Address::generate(&env);
         // Contract is not initialized — set_active should return NotInitialized
         let result = client.try_set_active(&symbol_short!("UNINIT"), &true);
         assert_eq!(result, Err(Ok(ContractError::NotInitialized)));
+    }
+
+    #[test]
+    fn test_initialize_returns_already_initialized_on_second_call() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SolarGridContract);
+        let client = SolarGridContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_address = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        client.initialize(&admin, &token_address);
+
+        let result = client.try_initialize(&admin, &token_address);
+        assert_eq!(result, Err(Ok(ContractError::AlreadyInitialized)));
+    }
+
+    #[test]
+    fn test_get_meter_returns_meter_not_found_for_unknown_meter() {
+        let (_env, client, _admin) = setup();
+        let result = client.try_get_meter(&symbol_short!("MISS_MTR"));
+        assert!(matches!(result, Err(Ok(ContractError::MeterNotFound))));
+    }
+
+    #[test]
+    fn test_withdraw_revenue_returns_unauthorized_for_non_admin() {
+        let (env, client, _admin, _token_address) = setup_with_token();
+        let provider = Address::generate(&env);
+        let result = client.try_withdraw_revenue(&provider, &1_i128);
+        assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
     }
 
     // ── Migration tests ───────────────────────────────────────────────────────

--- a/frontend/src/app/dashboard/provider/page.tsx
+++ b/frontend/src/app/dashboard/provider/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Navbar from "@/components/Navbar";
+import { useToast } from "@/components/ToastProvider";
 
 const API = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:3001";
 
@@ -10,14 +11,13 @@ function isValidStellarAddress(addr: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(addr);
 }
 
-type Status = "idle" | "loading" | "success" | "error";
+type Status = "idle" | "loading";
 
 export default function ProviderDashboardPage() {
+  const { showToast } = useToast();
   const [meterId, setMeterId] = useState("");
   const [ownerAddress, setOwnerAddress] = useState("");
   const [status, setStatus] = useState<Status>("idle");
-  const [message, setMessage] = useState("");
-  const [txHash, setTxHash] = useState("");
 
   const addressInvalid = ownerAddress.length > 0 && !isValidStellarAddress(ownerAddress);
 
@@ -28,14 +28,15 @@ export default function ProviderDashboardPage() {
   async function handleRegister(e: React.FormEvent) {
     e.preventDefault();
     if (!isValidStellarAddress(ownerAddress.trim())) {
-      setStatus("error");
-      setMessage("Invalid Stellar address. Must start with G and be 56 characters.");
+      showToast({
+        variant: "error",
+        title: "Registration failed",
+        description: "Invalid Stellar address. Must start with G and be 56 characters.",
+      });
       return;
     }
 
     setStatus("loading");
-    setMessage("");
-    setTxHash("");
 
     try {
       const res = await fetch(`${API}/api/meters`, {
@@ -49,21 +50,28 @@ export default function ProviderDashboardPage() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Registration failed");
 
-      setTxHash(data.hash);
-      setStatus("success");
-      setMessage("Meter registered successfully.");
+      showToast({
+        variant: "success",
+        title: "Meter registered",
+        description: `${meterId.trim()} was registered successfully.`,
+        actionHref: `${EXPLORER_BASE}/${data.hash}`,
+        actionLabel: "View transaction",
+      });
       setMeterId("");
       setOwnerAddress("");
     } catch (err: unknown) {
-      setStatus("error");
-      setMessage(err instanceof Error ? err.message : "Registration failed");
+      showToast({
+        variant: "error",
+        title: "Registration failed",
+        description: err instanceof Error ? err.message : "Registration failed",
+      });
+    } finally {
+      setStatus("idle");
     }
   }
 
   function reset() {
     setStatus("idle");
-    setMessage("");
-    setTxHash("");
   }
 
   return (
@@ -123,29 +131,6 @@ export default function ProviderDashboardPage() {
                 </p>
               )}
             </div>
-
-            {/* Feedback */}
-            {status === "error" && (
-              <div className="flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-900/20 px-4 py-3 text-sm text-red-400">
-                <span>✕</span>
-                <span>{message}</span>
-              </div>
-            )}
-            {status === "success" && (
-              <div className="rounded-lg border border-green-500/40 bg-green-900/20 px-4 py-3 text-sm text-green-400">
-                <div className="font-semibold mb-1">✓ {message}</div>
-                {txHash && (
-                  <a
-                    href={`${EXPLORER_BASE}/${txHash}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-400 underline underline-offset-2 font-mono text-xs hover:text-blue-300 transition"
-                  >
-                    {txHash.slice(0, 10)}…{txHash.slice(-8)} ↗
-                  </a>
-                )}
-              </div>
-            )}
 
             <button
               type="submit"

--- a/frontend/src/app/dashboard/user/page.tsx
+++ b/frontend/src/app/dashboard/user/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
 import { SkeletonCard } from "@/components/SkeletonCard";
+import { useToast } from "@/components/ToastProvider";
 import { useWalletStore } from "@/store/walletStore";
 import { getMeter, getMetersByOwner, type MeterData } from "@/services/meterService";
 import { parseWalletError } from "@/lib/errors";
@@ -94,6 +95,7 @@ function MeterCard({ meterId, meter }: { meterId: string; meter: MeterData }) {
 
 export default function UserDashboardPage() {
   const { address, connect } = useWalletStore();
+  const { showToast } = useToast();
 
   const [meterIds, setMeterIds] = useState<string[]>([]);
   const [meters, setMeters] = useState<Record<string, MeterData>>({});
@@ -112,11 +114,17 @@ export default function UserDashboardPage() {
       setMeters(Object.fromEntries(entries));
       setLastRefresh(new Date());
     } catch (err: unknown) {
-      setError(parseWalletError(err));
+      const friendly = parseWalletError(err);
+      setError(friendly);
+      showToast({
+        variant: "error",
+        title: "Failed to load meters",
+        description: friendly,
+      });
     } finally {
       setLoading(false);
     }
-  }, [address]);
+  }, [address, showToast]);
 
   useEffect(() => {
     if (!address) {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ToastProvider } from "@/components/ToastProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,7 +10,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/src/app/pay/page.tsx
+++ b/frontend/src/app/pay/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import Navbar from "@/components/Navbar";
 import OfflinePaymentModal from "@/components/OfflinePaymentModal";
+import { useToast } from "@/components/ToastProvider";
 import { useWalletStore } from "@/store/walletStore";
 import { usePaymentStore } from "@/store/paymentStore";
 import { useOffline } from "@/hooks/useOffline";
@@ -11,7 +11,7 @@ import { makePayment } from "@/services/meterService";
 import { parseWalletError } from "@/lib/errors";
 
 type Plan = "Daily" | "Weekly" | "Usage";
-type Status = "idle" | "loading" | "success" | "error" | "cancelled";
+type Status = "idle" | "loading";
 
 const PLANS: { value: Plan; label: string; desc: string }[] = [
   { value: "Daily",  label: "Daily",       desc: "Billed every 24 hours" },
@@ -22,12 +22,11 @@ const PLANS: { value: Plan; label: string; desc: string }[] = [
 export default function PayPage() {
   const { address, connect } = useWalletStore();
   const { meterId, plan, setMeterId, setPlan } = usePaymentStore();
+  const { showToast } = useToast();
   const isOffline = useOffline();
 
   const [amount, setAmount]       = useState("");
   const [status, setStatus]       = useState<Status>("idle");
-  const [message, setMessage]     = useState("");
-  const [txHash, setTxHash]       = useState("");
   const [showSmsModal, setShowSmsModal] = useState(false);
 
   const EXPLORER_BASE = process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE?.includes("Test")
@@ -42,25 +41,30 @@ export default function PayPage() {
     if (!meterId.trim() || isNaN(amountNum) || amountNum <= 0) return;
 
     setStatus("loading");
-    setMessage("");
-    setTxHash("");
 
     try {
       const hash = await makePayment(address, meterId.trim(), amountNum, plan);
-      setTxHash(hash);
-      setStatus("success");
-      setMessage("Payment successful!");
+      showToast({
+        variant: "success",
+        title: "Payment successful",
+        description: `${meterId.trim()} was topped up with ${amountNum.toFixed(2)} XLM.`,
+        actionHref: `${EXPLORER_BASE}/${hash}`,
+        actionLabel: "View transaction",
+      });
+      setAmount("");
     } catch (err: unknown) {
       const friendly = parseWalletError(err);
-      setStatus(friendly === "Transaction cancelled by user." ? "cancelled" : "error");
-      setMessage(friendly);
+      showToast({
+        variant: "error",
+        title:
+          friendly === "Transaction cancelled by user."
+            ? "Payment cancelled"
+            : "Payment failed",
+        description: friendly,
+      });
+    } finally {
+      setStatus("idle");
     }
-  }
-
-  function reset() {
-    setStatus("idle");
-    setMessage("");
-    setTxHash("");
   }
 
   return (
@@ -172,7 +176,7 @@ export default function PayPage() {
                 <input
                   type="number"
                   value={amount}
-                  onChange={(e) => { setAmount(e.target.value); reset(); }}
+                  onChange={(e) => setAmount(e.target.value)}
                   placeholder="0.00"
                   min="0.0000001"
                   step="any"
@@ -204,41 +208,6 @@ export default function PayPage() {
                   ))}
                 </div>
               </div>
-
-              {/* Feedback */}
-              {status === "cancelled" && (
-                <div className="flex items-center gap-2 rounded-lg border border-yellow-500/40 bg-yellow-900/20 px-4 py-3 text-sm text-yellow-300">
-                  <span>⚠️</span>
-                  <span>{message}</span>
-                </div>
-              )}
-              {status === "error" && (
-                <div className="flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-900/20 px-4 py-3 text-sm text-red-400">
-                  <span>✕</span>
-                  <span>{message}</span>
-                </div>
-              )}
-              {status === "success" && (
-                <div className="rounded-lg border border-green-500/40 bg-green-900/20 px-4 py-3 text-sm text-green-400">
-                  <div className="font-semibold mb-1">✓ {message}</div>
-                  {txHash && (
-                    <a
-                      href={`${EXPLORER_BASE}/${txHash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block text-blue-400 underline underline-offset-2 font-mono text-xs hover:text-blue-300 transition mb-2"
-                    >
-                      {txHash.slice(0, 10)}…{txHash.slice(-8)} ↗
-                    </a>
-                  )}
-                  <Link
-                    href="/dashboard/user"
-                    className="inline-block mt-1 text-xs text-green-300 underline underline-offset-2 hover:text-green-200 transition"
-                  >
-                    ← Back to My Meter
-                  </Link>
-                </div>
-              )}
 
               {/* Submit */}
               <button

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+
+type ToastVariant = "success" | "error";
+
+export type ToastOptions = {
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  actionHref?: string;
+  actionLabel?: string;
+};
+
+type ToastRecord = ToastOptions & {
+  id: string;
+  variant: ToastVariant;
+};
+
+type ToastContextValue = {
+  showToast: (options: ToastOptions) => void;
+  dismissToast: (id: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+function buildToastId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const timeoutsRef = useRef(new Map<string, number>());
+
+  const dismissToast = useCallback((id: string) => {
+    const timeoutId = timeoutsRef.current.get(id);
+    if (timeoutId) {
+      window.clearTimeout(timeoutId);
+      timeoutsRef.current.delete(id);
+    }
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((options: ToastOptions) => {
+    const id = buildToastId();
+    const toast: ToastRecord = {
+      id,
+      variant: options.variant ?? "success",
+      ...options,
+    };
+
+    setToasts((current) => [...current.slice(-2), toast]);
+
+    const timeoutId = window.setTimeout(() => {
+      dismissToast(id);
+    }, 5_000);
+
+    timeoutsRef.current.set(id, timeoutId);
+  }, [dismissToast]);
+
+  useEffect(() => {
+    const timeouts = timeoutsRef.current;
+
+    return () => {
+      for (const timeoutId of timeouts.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      timeouts.clear();
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast, dismissToast }}>
+      {children}
+      <div
+        aria-atomic="true"
+        aria-live="assertive"
+        className="pointer-events-none fixed inset-x-4 top-4 z-[60] flex flex-col items-end gap-3 sm:left-auto sm:right-4 sm:w-full sm:max-w-sm"
+      >
+        {toasts.map((toast) => {
+          const chrome =
+            toast.variant === "success"
+              ? "border-green-500/40 bg-green-950/90 text-green-100"
+              : "border-red-500/40 bg-red-950/90 text-red-100";
+          const accent =
+            toast.variant === "success" ? "bg-green-400" : "bg-red-400";
+
+          return (
+            <div
+              key={toast.id}
+              role="alert"
+              className={`pointer-events-auto w-full rounded-xl border px-4 py-3 shadow-2xl backdrop-blur ${chrome}`}
+            >
+              <div className="flex items-start gap-3">
+                <span
+                  aria-hidden="true"
+                  className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${accent}`}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold">{toast.title}</p>
+                  {toast.description && (
+                    <p className="mt-1 text-sm text-current/80">
+                      {toast.description}
+                    </p>
+                  )}
+                  {toast.actionHref && toast.actionLabel && (
+                    <a
+                      href={toast.actionHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-block text-xs font-semibold underline underline-offset-2 hover:opacity-80"
+                    >
+                      {toast.actionLabel} ↗
+                    </a>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => dismissToast(toast.id)}
+                  aria-label="Dismiss notification"
+                  className="rounded-md p-1 text-current/70 transition hover:bg-white/10 hover:text-current"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider");
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a reusable frontend toast system and wire it into payment and dashboard flows
- add reusable zod request validation middleware across meter and webhook routes
- replace contract panic-based failures with typed errors, including duplicate meter registration

## Verification
- cargo test
- npm run build (backend)
- npm run build (frontend)

Closes #71
Closes #72
Closes #81
Closes #91