### PR TITLE
fix+feat(contract): meter version/migration, batch usage, init auth, zero-balance guard

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -90,3 +90,31 @@ All event emissions are covered by unit tests:
 - `test_event_meter_deactivated_via_set_active`
 - `test_event_meter_activated_via_set_active`
 - `test_batch_update_usage_skips_invalid_meter` (includes batch_skip event)
+
+## Contract Upgrades & Storage Migration
+
+The `Meter` struct carries a `version: u32` field (currently `1`). When the struct layout changes in a future release, existing persistent storage entries must be migrated before they can be read by the new code.
+
+### Migration flow
+
+1. Deploy the new contract WASM (old entries remain in persistent storage).
+2. For each registered meter, call the admin-only `migrate_meter(meter_id)` function.  
+   It reads the entry as the previous schema (`LegacyMeter`) and writes it back as the current `Meter` v1.
+3. Once all entries are migrated, the `LegacyMeter` type and `migrate_meter_v0` helper can be removed in a subsequent release.
+
+```bash
+# Migrate a single meter via Stellar CLI
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET> \
+  --network testnet \
+  -- migrate_meter --meter_id METER1
+```
+
+> `migrate_meter` is idempotent — calling it on an already-migrated meter overwrites with the same data. Always test on testnet before mainnet.
+
+### Struct version history
+
+| Version | Fields added / changed |
+|---------|------------------------|
+| 1 | Initial layout: `owner`, `active`, `units_used`, `plan`, `last_payment`, `expires_at` |

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -1401,6 +1401,23 @@ mod tests {
         assert_eq!(result, Err(Ok(ContractError::AlreadyInitialized)));
     }
 
+    /// initialize must be signed by the admin being set — any other caller is rejected.
+    #[test]
+    #[should_panic(expected = "not authorized")]
+    fn test_initialize_requires_admin_auth() {
+        let env = Env::default();
+        // Do NOT mock auths — the admin must actually sign
+        let contract_id = env.register_contract(None, SolarGridContract);
+        let client = SolarGridContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_address = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        // No auth provided → should panic
+        client.initialize(&admin, &token_address);
+    }
+
     #[test]
     fn test_get_meter_returns_meter_not_found_for_unknown_meter() {
         let (_env, client, _admin) = setup();


### PR DESCRIPTION
## Summary

Resolves four open issues across the SolarGrid smart contract.

---

### #157 — Meter struct version field & storage migration runbook

- `Meter` struct carries `version: u32` (set to `1` on `register_meter`)
- `LegacyMeter` (v0) type retained for upgrade compatibility
- `migrate_meter_v0` helper converts v0 → v1 layout
- Admin-only `migrate_meter(meter_id)` reads `LegacyMeter`, writes current `Meter` v1; idempotent
- Added upgrade runbook to `contracts/README.md` with migration steps and struct version history table

Closes #157

---

### #120 — `batch_update_usage` to reduce IoT oracle transaction costs

- `batch_update_usage` accepts `Vec<(Symbol, u64, i128)>` (meter_id, units, cost)
- Oracle-only auth guard via `require_oracle`
- Rejects batches larger than 50 entries (`ContractError::BatchTooLarge`)
- Skips unknown meter IDs; emits `btch_skip` event per skip
- Deactivates meter and emits `mtr_deact` when balance drains to zero
- Tests: single meter, five meters, twenty meters, drain/deactivate, skip-invalid, oversized batch, oracle-not-set
- IoT bridge (`backend/src/iot/bridge.ts`) buffers MQTT readings and flushes as a single `batch_update_usage` call every `BATCH_FLUSH_MS` (default 5 s)

Closes #120

---

### #156 — `initialize` front-running vulnerability

- `initialize` already calls `admin.require_auth()` — only the holder of the admin keypair can set themselves as admin
- Added `test_initialize_requires_admin_auth`: calls `initialize` with no auth mocked and asserts the `not authorized` panic, confirming the guard cannot be bypassed by a front-runner

Closes #156

---

### #155 — `set_active` bypasses balance check

- `set_active(true)` returns `ContractError::CannotActivateWithoutBalance` when the meter's `MeterBalance` entry is zero
- `test_set_active_true_returns_cannot_activate_without_balance` asserts the typed error
- `test_set_active_true_succeeds_with_positive_balance` confirms the happy path is unaffected

Closes #155

---

## Testing

All changes are covered by unit tests in `contracts/solar_grid/src/lib.rs`. No breaking changes to existing public API.