### PR TITLE
feat: batch usage updates, tx confirmation polling, and Zod validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,29 @@
+# Changes
+
+## batch_update_usage, tx confirmation polling, Zod validation
+
+### feat(contract): `batch_update_usage` (closes #160, #169)
+
+Added `batch_update_usage(updates: Vec<(Symbol, u64, i128)>)` to the Soroban
+contract. The IoT oracle previously called `update_usage` once per meter per
+cycle, producing 100+ separate transactions for large deployments. The new
+function processes up to 50 readings in a single transaction.
+
+- Oracle-gated; rejects batches larger than 50 (`BatchTooLarge`)
+- Skips unknown meter IDs and emits `batch_skip` rather than aborting the batch
+- Deactivates meters whose balance reaches zero and emits `mtr_deact`
+- IoT bridge buffers MQTT readings and flushes via `batch_update_usage` on a
+  configurable interval (`BATCH_FLUSH_MS`, default 5 s)
+
+### fix(backend): `adminInvoke` waits for on-chain confirmation (closes #170)
+
+`server.sendTransaction()` returns immediately while the transaction is still
+`PENDING`. `adminInvoke` now polls `server.getTransaction(hash)` until the
+status is `SUCCESS` or `FAILED`, or until `TX_TIMEOUT_MS` (default 30 s) is
+reached. A timeout error is thrown if the deadline is exceeded.
+
+### feat(backend): Zod request validation on all API routes (closes #171)
+
+A `validateRequest` middleware backed by Zod now guards every mutating route.
+Invalid requests receive a structured `400` response with per-field error
+details before any contract call is made.


### PR DESCRIPTION
## Summary


### feat(contract): `batch_update_usage` — closes #160, #169

The IoT oracle previously called `update_usage` once per meter per cycle, producing 100+ separate transactions for large deployments. A new `batch_update_usage(updates: Vec<(Symbol, u64, i128)>)` function processes up to 50 meter readings in a single transaction.

- Oracle-gated; rejects batches larger than 50 entries (`BatchTooLarge`)
- Skips unknown meter IDs and emits a `batch_skip` event rather than aborting the whole batch
- Deactivates meters whose balance reaches zero and emits `mtr_deact` per affected meter
- IoT bridge (`backend/src/iot/bridge.ts`) buffers MQTT readings and flushes them via `batch_update_usage` on a configurable interval (`BATCH_FLUSH_MS`, default 5 s)

### fix(backend): `adminInvoke` waits for on-chain confirmation — closes #170

`server.sendTransaction()` returns immediately with a hash while the transaction is still `PENDING`. Callers were treating the hash as a success signal, which is incorrect.

`adminInvoke` now polls `server.getTransaction(hash)` until the status is `SUCCESS` or `FAILED`, or until a configurable deadline (`TX_TIMEOUT_MS`, default 30 s) is reached. A `timeout` error is thrown if the deadline is exceeded, preventing silent failures.

### feat(backend): Zod request validation on all API routes — closes #171

Invalid payloads previously reached the Stellar SDK and produced cryptic XDR errors. A `validateRequest` middleware (backed by Zod) now guards every route:

| Route | Schema |
|---|---|
| `POST /api/meters` | `RegisterMeterSchema` |
| `POST /api/meters/:id/usage` | `MeterRouteParamsSchema` + `UsageUpdateSchema` |
| `POST /api/meters/:id/pay` | `MeterRouteParamsSchema` + `MakePaymentSchema` |
| `POST /api/webhooks/sms-payment` | `SmsPaymentWebhookSchema` |

Invalid requests receive a structured `400` response with per-field error details before any contract call is made.

---
Closes #160
Closes #169
Closes #170
Closes #171

## Testing

- Contract: `cargo test` — all existing tests pass; new `batch_update_usage` tests cover single-meter, multi-meter, drain/deactivate, skip-invalid, and oversized-batch cases.
- Backend: TypeScript compiles cleanly; validation middleware guards all mutating routes.