### PR TITLE
fix: validate units and cost are positive integers in usage route

### DIFF
--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -71,15 +71,36 @@ meterRouter.post(
 
 /** POST /api/meters/:id/usage — IoT oracle reports usage */
 meterRouter.post("/:id/usage", async (req, res) => {
-  const { units, cost } = req.body as { units: number; cost: number };
+  const { units, cost } = req.body as { units: unknown; cost: unknown };
+
+  // Presence check
   if (units == null || cost == null) {
     return res.status(400).json({ error: "units and cost are required" });
   }
+
+  const unitsNum = Number(units);
+  const costNum  = Number(cost);
+
+  // Must be finite numbers
+  if (!Number.isFinite(unitsNum) || !Number.isFinite(costNum)) {
+    return res.status(400).json({ error: "units and cost must be valid numbers" });
+  }
+
+  // Must be integers
+  if (!Number.isInteger(unitsNum) || !Number.isInteger(costNum)) {
+    return res.status(400).json({ error: "units and cost must be integers" });
+  }
+
+  // Must be strictly positive — rejects zero and negative values
+  if (unitsNum <= 0 || costNum <= 0) {
+    return res.status(400).json({ error: "units and cost must be positive" });
+  }
+
   try {
     const event = await persistAndSubmitUsageEvent({
       meterId: req.params.id,
-      units,
-      cost,
+      units: unitsNum,
+      cost: costNum,
       sourceTopic: null,
     });
 
@@ -91,8 +112,4 @@ meterRouter.post("/:id/usage", async (req, res) => {
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
-
-  paymentVolume.inc(amount_stroops / 10_000_000);
-  activeMeters.inc();
-  res.json({ hash });
-}));
+});


### PR DESCRIPTION
## Summary

Closes #178

Adds strict input validation to `POST /api/meters/:id/usage` so the contract is never called with invalid data.

## Validation added (in order)

1. **Presence** - `units` and `cost` must be provided (existing check kept)
2. **Numeric** - both must be finite numbers (rejects `NaN`, `Infinity`, strings)
3. **Integer** - both must be whole numbers (rejects `1.5`, `0.3`)
4. **Positive** - both must be `> 0` (rejects zero and negative values)

Each check returns `400` with a descriptive error message before `persistAndSubmitUsageEvent` is ever called.

## Error responses

| Input | Status | Message |
|---|---|---|
| Missing field | 400 | `units and cost are required` |
| `"abc"` / `NaN` | 400 | `units and cost must be valid numbers` |
| `1.5` / `0.3` | 400 | `units and cost must be integers` |
| `0` / `-5` | 400 | `units and cost must be positive` |
| Valid | 200 | event + hash |

## Acceptance Criteria

- [x] Validation rejects negative or zero values with 400
- [x] Non-integer values rejected with 400
- [x] Contract is never called with invalid data