### PR TITLE
fix(backend): validate MQTT payload schema in IoT bridge (closes #179)

### DIFF
--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -9,7 +9,9 @@
  */
 
 import mqtt from "mqtt";
+import { logger } from "../lib/logger.js";
 import { persistAndSubmitUsageEvent } from "../lib/usageEvents.js";
+import { UsageUpdateSchema } from "../lib/validation.js";
 
 const BROKER = process.env.MQTT_BROKER ?? "mqtt://localhost:1883";
 const TOPIC = "solargrid/meters/+/usage";
@@ -68,10 +70,24 @@ function startMqttBridge() {
     mqttMessages.inc();
     try {
       const meterId = topic.split("/")[2];
-      const { units, cost } = JSON.parse(payload.toString()) as {
-        units: number;
-        cost: number;
-      };
+
+      let raw: unknown;
+      try {
+        raw = JSON.parse(payload.toString());
+      } catch (err) {
+        logger.error("Invalid MQTT payload (not JSON)", { topic, err });
+        return;
+      }
+
+      const parsed = UsageUpdateSchema.safeParse(raw);
+      if (!parsed.success) {
+        logger.error("Invalid MQTT payload (schema validation failed)", {
+          topic,
+          errors: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+      const { units, cost } = parsed.data;
 
       console.log(`⚡ Usage update — meter: ${meterId}, units: ${units}, cost: ${cost}`);
 


### PR DESCRIPTION
## Summary
Closes #179.

The MQTT bridge previously parsed payloads with raw `JSON.parse()` and destructured `units` / `cost` without validation — a malformed or malicious message (missing fields, string values, `null`, NaN, non-positive numbers) would pass invalid data straight to the contract submission path.

This change wraps payload handling with:
- explicit `JSON.parse` in its own try/catch (non-JSON → logged & discarded)
- `UsageUpdateSchema.safeParse` (the existing zod schema already used by the HTTP usage route in #178) — invalid schema → logged & discarded
- both failure paths return early without invoking the contract

Reusing the existing `UsageUpdateSchema` keeps the HTTP and MQTT validation rules consistent (positive-integer `units` and `cost`, strict object — no extra fields).

## DoD checklist
- [x] Zod schema validation added to bridge message handler
- [x] Invalid payloads are logged (`logger.error` with topic + field errors) and discarded without calling the contract
- [ ] Unit test simulates malformed MQTT messages — _deferred: backend has no test runner configured (frontend uses jest, contract has Rust tests). Happy to add a vitest setup + tests as a follow-up PR if preferred over piggybacking it onto this fix._
- [x] No unhandled exceptions thrown on bad input — both `JSON.parse` errors and schema failures are handled inline

## Test plan
- [ ] Send well-formed payload `{"units":100,"cost":500000}` → bridge logs the usage update and submits to the contract path.
- [ ] Send malformed JSON (e.g. `not json`) → logged as `Invalid MQTT payload (not JSON)`, no contract call.
- [ ] Send schema-invalid payload `{"units":"drop table","cost":null}` → logged as `Invalid MQTT payload (schema validation failed)` with field errors, no contract call.
- [ ] Send negative/zero values `{"units":-1,"cost":0}` → rejected by schema (positive-int rule), no contract call.