### PR TITLE
feat(backend): complete structured logging migration (closes #180)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import { meterRouter } from "./routes/meters.js";
 import { paymentsRouter } from "./routes/payments.js";
 import { webhookRouter } from "./routes/webhooks.js";
 import { startIoTBridge } from "./iot/bridge.js";
+import { logger } from "./lib/logger.js";
 import {
   initUsageEventStore,
   startUsageEventRetryWorker,
@@ -67,6 +68,6 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
 app.listen(PORT, () => {
   initUsageEventStore();
   startUsageEventRetryWorker();
-  console.log(`🌞 SolarGrid backend running on port ${PORT}`);
+  logger.info("SolarGrid backend listening", { port: PORT });
   startIoTBridge();
 });

--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -9,6 +9,7 @@
  */
 
 import mqtt from "mqtt";
+import { logger } from "../lib/logger.js";
 import { persistAndSubmitUsageEvent } from "../lib/usageEvents.js";
 
 const BROKER = process.env.MQTT_BROKER ?? "mqtt://localhost:1883";
@@ -73,7 +74,11 @@ function startMqttBridge() {
         cost: number;
       };
 
-      console.log(`⚡ Usage update — meter: ${meterId}, units: ${units}, cost: ${cost}`);
+      logger.info("Usage update received from IoT bridge", {
+        meterId,
+        units,
+        cost,
+      });
 
       const event = await persistAndSubmitUsageEvent({
         meterId,
@@ -83,9 +88,16 @@ function startMqttBridge() {
       });
 
       if (event.on_chain_tx_hash) {
-        console.log(`✅ Usage recorded on-chain: ${event.on_chain_tx_hash}`);
+        logger.info("Usage recorded on-chain", {
+          meterId,
+          eventId: event.id,
+          txHash: event.on_chain_tx_hash,
+        });
       } else {
-        console.warn(`⏳ Usage event ${event.id} queued for retry`);
+        logger.warn("Usage event queued for retry", {
+          meterId,
+          eventId: event.id,
+        });
       }
     } catch (err) {
       logger.error("IoT bridge parse error", { err });
@@ -103,7 +115,7 @@ function startMqttBridge() {
 let lastProcessedLedger = 0;
 
 function startContractEventListener() {
-  console.log("🔔 Contract event listener started");
+  logger.info("Contract event listener started");
   setInterval(pollContractEvents, EVENT_POLL_INTERVAL_MS);
 }
 
@@ -137,7 +149,7 @@ async function pollContractEvents() {
 
     lastProcessedLedger = currentLedger;
   } catch (err) {
-    console.error("Contract event poll error:", err);
+    logger.error("Contract event poll error", { err });
   }
 }
 
@@ -161,9 +173,10 @@ async function handleContractEvent(
         const data = event.value;
         const native = StellarSdk.scValToNative(data) as [string, bigint, unknown];
         const [meterId, amount] = native;
-        console.log(
-          `💰 payment_received — meter: ${meterId}, amount: ${Number(amount) / 10_000_000} XLM`,
-        );
+        logger.info("payment_received contract event", {
+          meterId: String(meterId),
+          amountXlm: Number(amount) / 10_000_000,
+        });
         await onPaymentReceived(String(meterId), Number(amount));
         break;
       }
@@ -171,7 +184,7 @@ async function handleContractEvent(
       case "meter:activated": {
         const data = event.value;
         const meterId = String(StellarSdk.scValToNative(data));
-        console.log(`✅ meter_activated — meter: ${meterId}`);
+        logger.info("meter_activated contract event", { meterId });
         await onMeterActivated(meterId);
         break;
       }
@@ -179,7 +192,7 @@ async function handleContractEvent(
       case "meter:deactivated": {
         const data = event.value;
         const meterId = String(StellarSdk.scValToNative(data));
-        console.log(`🔴 meter_deactivated — meter: ${meterId}`);
+        logger.info("meter_deactivated contract event", { meterId });
         await onMeterDeactivated(meterId);
         break;
       }
@@ -188,7 +201,7 @@ async function handleContractEvent(
         break;
     }
   } catch (err) {
-    console.error("Error handling contract event:", err);
+    logger.error("Error handling contract event", { err });
   }
 }
 
@@ -197,19 +210,20 @@ async function handleContractEvent(
 async function onPaymentReceived(meterId: string, amountStroops: number) {
   // Placeholder: notify downstream services, update a cache, send a push
   // notification, etc.
-  console.log(
-    `[handler] Payment received for meter ${meterId}: ${amountStroops / 10_000_000} XLM`,
-  );
+  logger.info("Payment received handler", {
+    meterId,
+    amountXlm: amountStroops / 10_000_000,
+  });
 }
 
 async function onMeterActivated(meterId: string) {
   // Send ON signal to the physical smart meter via MQTT or HTTP
-  console.log(`[handler] Sending ON signal to meter ${meterId}`);
+  logger.info("Sending ON signal to meter", { meterId });
   // e.g. mqttClient.publish(`solargrid/meters/${meterId}/control`, JSON.stringify({ cmd: "ON" }));
 }
 
 async function onMeterDeactivated(meterId: string) {
   // Send OFF signal to the physical smart meter via MQTT or HTTP
-  console.log(`[handler] Sending OFF signal to meter ${meterId}`);
+  logger.info("Sending OFF signal to meter", { meterId });
   // e.g. mqttClient.publish(`solargrid/meters/${meterId}/control`, JSON.stringify({ cmd: "OFF" }));
 }

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,11 +1,25 @@
 import winston from "winston";
 
+const isProduction = process.env.NODE_ENV === "production";
+
+const developmentFormat = winston.format.combine(
+  winston.format.colorize(),
+  winston.format.timestamp({ format: "HH:mm:ss" }),
+  winston.format.printf(({ timestamp, level, message, ...meta }) => {
+    const metaKeys = Object.keys(meta);
+    const metaStr = metaKeys.length > 0 ? ` ${JSON.stringify(meta)}` : "";
+    return `${timestamp} ${level} ${message}${metaStr}`;
+  }),
+);
+
+const productionFormat = winston.format.combine(
+  winston.format.timestamp(),
+  winston.format.json(),
+);
+
 export const logger = winston.createLogger({
   level: process.env.LOG_LEVEL ?? "info",
-  format: winston.format.combine(
-    winston.format.timestamp(),
-    winston.format.json()
-  ),
+  format: isProduction ? productionFormat : developmentFormat,
   transports: [
     new winston.transports.Console(),
     new winston.transports.File({ filename: "logs/error.log", level: "error" }),


### PR DESCRIPTION
## Summary
Closes #180.

`winston` and `lib/logger.ts` already exist (introduced in earlier PR #?). This change finishes the migration by:

1. **Adding a dev-vs-prod log format** in `lib/logger.ts` — colorized human-readable output in development, structured JSON in production. Matches the spirit of the issue's pino-pretty / raw-JSON split using winston.
2. **Migrating the remaining `console.*` calls** to `logger.*` with structured context fields:
   - `index.ts`: startup banner → `logger.info("SolarGrid backend listening", { port })`
   - `iot/bridge.ts`: 12 calls (usage updates, on-chain confirmations, retry queueing, contract event logging, meter activation/deactivation handlers, payment-received handler, error paths) — each now uses an appropriate level (info/warn/error) with structured fields like `meterId`, `eventId`, `txHash`, `amountXlm`, `err`.

## DoD checklist
- [x] Logger module created (already existed via winston)
- [x] All `console.log` / `console.error` / `console.warn` replaced with structured logger calls (verified `grep -rn "console\\." backend/src/` returns nothing)
- [x] Log level configurable via `LOG_LEVEL` env var (already supported in logger.ts)
- [x] Logs include relevant context fields (meterId, txHash, eventId, amountXlm, port, err)
- [x] Human-readable format in development, JSON in production (driven by `NODE_ENV`)

## Notes
- Backend uses `winston` (the issue listed pino *or* winston; winston was already wired in).
- Two atomic commits: (1) logger format change, (2) call-site migration.
- This PR adds a logger import to `index.ts` and `iot/bridge.ts`, both of which already referenced `logger` without an import (pre-existing build breakage on `main` — see also PR #188 which adds the same import to `bridge.ts` for #179; trivial conflict resolution at merge).

## Test plan
- [ ] `NODE_ENV=development npm run dev` — logs render colorized with HH:mm:ss timestamps and inline meta.
- [ ] `NODE_ENV=production node dist/index.js` — logs render as JSON lines suitable for aggregation.
- [ ] `LOG_LEVEL=debug` honored by the logger; default `info` filters out debug.
- [ ] Trigger an MQTT usage update — verify `Usage update received from IoT bridge` includes `meterId`, `units`, `cost`.
- [ ] Trigger a contract event (or simulate) — verify `payment_received contract event` includes `meterId` and `amountXlm`.
- [ ] Trigger an error path — verify `err` is captured in structured form.