### PR TITLE
Fix/backend reliability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ The `SolarGrid` contract manages:
 | `check_access(meter_id)` | Check if meter is currently active |
 | `get_usage(meter_id)` | Retrieve usage data |
 | `update_usage(meter_id, units)` | Called by IoT oracle to update consumption |
+| `deactivate_meter(meter_id)` | Admin-only: immediately deactivate a meter |
+
+## Backend API
+
+### Meter Balance
+
+**`GET /api/meters/:id/balance`**
+
+Returns the live balance, usage, and active status for a single meter. Responses are cached for 5 seconds to reduce RPC load. The frontend `UserDashboard` polls this endpoint every 30 seconds.
+
+**Response**
+
+```json
+{
+  "meter_id": "METER1",
+  "balance": 5000000,
+  "units_used": 1200,
+  "active": true
+}
+```
+
+| Status | Description |
+|---|---|
+| 200 | Meter found, returns balance data |
+| 404 | Meter not found |
 
 ## Contract Upgrades
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,6 +17,9 @@ TX_POLL_INTERVAL_MS=2000
 # Accepts values like '15s', '30s', '1m'. Default: 15s
 REQUEST_TIMEOUT=15s
 
+# Max reconnect attempts for IoT bridge MQTT connection before alerting and stopping (default: 10)
+MQTT_MAX_RECONNECT_ATTEMPTS=10
+
 # Low-balance webhook configuration (optional)
 PROVIDER_WEBHOOK_URL=https://example.com/webhook
 LOW_BALANCE_THRESHOLD=1000000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,10 @@ TX_TIMEOUT_MS=30000
 TX_MAX_ATTEMPTS=15
 TX_POLL_INTERVAL_MS=2000
 
+# Request timeout — maximum time a request can take before returning 504.
+# Accepts values like '15s', '30s', '1m'. Default: 15s
+REQUEST_TIMEOUT=15s
+
 # Low-balance webhook configuration (optional)
 PROVIDER_WEBHOOK_URL=https://example.com/webhook
 LOW_BALANCE_THRESHOLD=1000000

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",
+    "connect-timeout": "^1.9.0",
     "better-sqlite3": "^11.7.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
@@ -21,6 +22,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/connect-timeout": "^0.0.39",
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.2",
     "tsx": "^4.15.1",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import express from "express";
+import timeout from "connect-timeout";
 import { NextFunction, Request, Response } from "express";
 import { stellarService } from "./lib/stellar.js";
 import { createMeterRouter } from "./routes/meters.js";
@@ -44,6 +45,15 @@ app.use((_, res, next) => {
   next();
 });
 
+// Request timeout — configurable via REQUEST_TIMEOUT env var (default 15s)
+const requestTimeout = process.env.REQUEST_TIMEOUT ?? '15s';
+app.use(timeout(requestTimeout));
+
+// Halt middleware chain if request has already timed out
+app.use((req: any, _res: any, next: any) => {
+  if (!req.timedout) next();
+});
+
 app.use((req, _res, next) => {
   logger.info({ method: req.method, path: req.path });
   next();
@@ -58,6 +68,19 @@ app.get("/health", (_, res) => res.json({ status: "ok" }));
 app.get("/metrics", async (_req, res) => {
   res.set("Content-Type", register.contentType);
   res.end(await register.metrics());
+});
+
+// Timeout error handler — must come before the generic error handler
+app.use((err: any, req: any, res: any, next: any) => {
+  if (req.timedout) {
+    logger.error('Request timed out', {
+      method: req.method,
+      path: req.path,
+      timeout: requestTimeout,
+    });
+    return res.status(504).json({ error: 'Request timed out' });
+  }
+  next(err);
 });
 
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {

--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -92,7 +92,26 @@ export function startIoTBridge() {
 }
 
 function startMqttBridge() {
-  const client = mqtt.connect(BROKER);
+  const client = mqtt.connect(BROKER, {
+    reconnectPeriod: 1000,       // start at 1s
+    connectTimeout: 10_000,
+  });
+
+  const MAX_RECONNECT_ATTEMPTS = Number(process.env.MQTT_MAX_RECONNECT_ATTEMPTS ?? 10);
+  let reconnectAttempts = 0;
+
+  client.on('reconnect', () => {
+    reconnectAttempts++;
+    if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+      logger.error('MQTT reconnect attempts exhausted', { maxAttempts: MAX_RECONNECT_ATTEMPTS });
+      client.end(); // stop reconnecting
+      return;
+    }
+    const delay = Math.min(1000 * 2 ** reconnectAttempts, 30_000);
+    client.options.reconnectPeriod = delay;
+    logger.warn({ attempt: reconnectAttempts, nextDelayMs: delay }, 'MQTT reconnecting');
+  });
+
   let pending: Reading[] = [];
 
   const flush = async () => {
@@ -112,6 +131,8 @@ function startMqttBridge() {
   setInterval(flush, FLUSH_INTERVAL_MS);
 
   client.on("connect", () => {
+    reconnectAttempts = 0;
+    client.options.reconnectPeriod = 1000;
     logger.info(`IoT bridge connected to ${BROKER}`);
     client.subscribe(TOPIC, (err) => {
       if (err) logger.error("MQTT subscribe error", { err });
@@ -174,7 +195,7 @@ function startMqttBridge() {
   });
 
   client.on("error", (err) => {
-    logger.warn("MQTT connection error (will retry)", { message: err.message });
+    logger.error({ err }, "MQTT error");
   });
 }
 

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { StellarService, stellarService } from "../lib/stellar.js";
+import { StellarService, stellarService, adminInvoke, contractQuery } from "../lib/stellar.js";
 import {
   getUsageHistory,
   persistAndSubmitUsageEvent,
@@ -52,6 +52,32 @@ meterRouter.get(
       StellarSdk.nativeToScVal(req.params.id, { type: "symbol" }),
     ]);
     res.json({ active: StellarSdk.scValToNative(result) });
+  }),
+);
+
+/** POST /api/meters/:id/deactivate — admin manually deactivates a meter */
+meterRouter.post(
+  "/:id/deactivate",
+  asyncHandler(async (req, res) => {
+    const meterId = req.params.id;
+
+    // Verify meter exists first
+    try {
+      await contractQuery("get_meter", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+      ]);
+    } catch {
+      return res.status(404).json({ error: "Meter not found" });
+    }
+
+    try {
+      const txHash = await adminInvoke("deactivate_meter", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+      ]);
+      res.json({ success: true, tx_hash: txHash, meter_id: meterId });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
   }),
 );
 

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -81,6 +81,40 @@ meterRouter.post(
   }),
 );
 
+/** GET /api/meters/:id/balance — live balance for a single meter */
+const balanceCache = new Map<string, { data: any; ts: number }>();
+const BALANCE_CACHE_TTL_MS = 5_000; // 5-second cache to reduce RPC load
+
+meterRouter.get(
+  "/:id/balance",
+  asyncHandler(async (req, res) => {
+    const meterId = req.params.id;
+
+    // Check cache first
+    const cached = balanceCache.get(meterId);
+    if (cached && Date.now() - cached.ts < BALANCE_CACHE_TTL_MS) {
+      return res.json(cached.data);
+    }
+
+    try {
+      const result = await contractQuery("get_meter", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+      ]);
+      const meter = StellarSdk.scValToNative(result) as any;
+      const payload = {
+        meter_id: meterId,
+        balance: meter.balance,
+        units_used: meter.units_used,
+        active: meter.active,
+      };
+      balanceCache.set(meterId, { data: payload, ts: Date.now() });
+      res.json(payload);
+    } catch (err: any) {
+      res.status(404).json({ error: "Meter not found" });
+    }
+  }),
+);
+
 /** GET /api/meters/:id/history — paginated local usage history */
 meterRouter.get("/:id/history", (req, res) => {
   const page = Math.max(1, Number(req.query.page ?? 1) || 1);

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -575,6 +575,30 @@ impl SolarGridContract {
         Ok(())
     }
 
+    /// Admin-only: immediately deactivate a meter (e.g. for non-paying
+    /// customers or faulty meters). Unlike `set_active`, this is a one-way
+    /// deactivation that doesn't require passing a boolean flag.
+    ///
+    /// Emits:
+    /// - `meter_deactivated { meter_id }`
+    pub fn deactivate_meter(env: Env, meter_id: Symbol) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        let key = DataKey::Meter(meter_id.clone());
+        let mut meter = Self::get_meter_or_error(&env, &key)?;
+        meter.active = false;
+        env.storage().persistent().set(&key, &meter);
+
+        env.events().publish(
+            (symbol_short!("access"), meter_id.clone()),
+            false,
+        );
+        env.events().publish(
+            (symbol_short!("mtr_deact"), EVT_NS, meter_id),
+            (),
+        );
+        Ok(())
+    }
+
     // ── Collaborator management ───────────────────────────────────────────────
 
     /// Add a collaborator with a share in basis points (100 = 1%).

--- a/frontend/src/app/dashboard/provider/page.tsx
+++ b/frontend/src/app/dashboard/provider/page.tsx
@@ -21,6 +21,7 @@ export default function ProviderDashboardPage() {
   const [meterId, setMeterId] = useState("");
   const [ownerAddress, setOwnerAddress] = useState("");
   const [status, setStatus] = useState<Status>("idle");
+  const [deactivatingId, setDeactivatingId] = useState<string | null>(null);
   
   const [meters, setMeters] = useState<MeterData[]>([]);
   const [fetching, setFetching] = useState(false);
@@ -47,6 +48,35 @@ export default function ProviderDashboardPage() {
   useEffect(() => {
     fetchMeters();
   }, [fetchMeters]);
+
+  async function handleDeactivate(id: string) {
+    setDeactivatingId(id);
+    try {
+      const res = await fetch(`${API}/api/meters/${id}/deactivate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Deactivation failed");
+
+      showToast({
+        variant: "success",
+        title: "Meter deactivated",
+        description: `${id} was deactivated successfully.`,
+        actionHref: `${EXPLORER_BASE}/${data.tx_hash}`,
+        actionLabel: "View transaction",
+      });
+      fetchMeters(); // Refresh list
+    } catch (err: unknown) {
+      showToast({
+        variant: "error",
+        title: "Deactivation failed",
+        description: err instanceof Error ? err.message : "Deactivation failed",
+      });
+    } finally {
+      setDeactivatingId(null);
+    }
+  }
 
   async function handleRegister(e: React.FormEvent) {
     e.preventDefault();
@@ -189,6 +219,7 @@ export default function ProviderDashboardPage() {
                     <th className="px-6 py-4 font-semibold">Plan</th>
                     <th className="px-6 py-4 font-semibold">Usage</th>
                     <th className="px-6 py-4 font-semibold">Expiry</th>
+                    <th className="px-6 py-4 font-semibold">Actions</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/5">
@@ -201,12 +232,13 @@ export default function ProviderDashboardPage() {
                           <td className="px-6 py-4"><Skeleton width="70px" height={14} /></td>
                           <td className="px-6 py-4"><Skeleton width="50px" height={14} /></td>
                           <td className="px-6 py-4"><Skeleton width="80px" height={14} /></td>
+                          <td className="px-6 py-4"><Skeleton width="80px" height={28} /></td>
                         </tr>
                       ))}
                     </>
                   ) : meters.length === 0 ? (
                     <tr>
-                      <td colSpan={5} className="px-6 py-12 text-center text-gray-500">
+                      <td colSpan={6} className="px-6 py-12 text-center text-gray-500">
                         No meters found.
                       </td>
                     </tr>
@@ -214,6 +246,7 @@ export default function ProviderDashboardPage() {
                     meters.map((m, i) => {
                       const expiresAt = Number(m.expires_at);
                       const isExpired = expiresAt !== Number.MAX_SAFE_INTEGER && expiresAt > 0 && Date.now() / 1000 >= expiresAt;
+                      const isActive = m.active && !isExpired;
                       
                       return (
                         <tr key={i} className="hover:bg-white/[0.02] transition">
@@ -222,10 +255,10 @@ export default function ProviderDashboardPage() {
                           </td>
                           <td className="px-6 py-4">
                             <span className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${
-                              m.active && !isExpired ? "bg-green-500/10 text-green-500" : "bg-red-500/10 text-red-500"
+                              isActive ? "bg-green-500/10 text-green-500" : "bg-red-500/10 text-red-500"
                             }`}>
-                              <span className={`h-1 w-1 rounded-full ${m.active && !isExpired ? "bg-green-500" : "bg-red-500"}`} />
-                              {m.active && !isExpired ? "Active" : "Inactive"}
+                              <span className={`h-1 w-1 rounded-full ${isActive ? "bg-green-500" : "bg-red-500"}`} />
+                              {isActive ? "Active" : "Inactive"}
                             </span>
                           </td>
                           <td className="px-6 py-4 text-xs font-medium">{m.plan}</td>
@@ -234,6 +267,17 @@ export default function ProviderDashboardPage() {
                           </td>
                           <td className="px-6 py-4 text-xs text-gray-400">
                             {expiresAt === Number.MAX_SAFE_INTEGER ? "Never" : new Date(expiresAt * 1000).toLocaleDateString()}
+                          </td>
+                          <td className="px-6 py-4">
+                            {isActive && (
+                              <button
+                                onClick={() => handleDeactivate(String(m.owner).slice(0, 12))}
+                                disabled={deactivatingId !== null}
+                                className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-400 hover:bg-red-500/20 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                              >
+                                {deactivatingId ? "Deactivating…" : "Deactivate"}
+                              </button>
+                            )}
                           </td>
                         </tr>
                       );
@@ -248,3 +292,4 @@ export default function ProviderDashboardPage() {
     </>
   );
 }
+

--- a/frontend/src/app/dashboard/user/page.tsx
+++ b/frontend/src/app/dashboard/user/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
 import UsageChart, { type UsageDataPoint } from "@/components/UsageChart";
@@ -12,6 +12,9 @@ import { parseWalletError } from "@/lib/errors";
 import { useToast } from "@/components/ToastProvider";
 
 const STROOPS_PER_XLM = 10_000_000n;
+
+const API = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:3001";
+const BALANCE_POLL_INTERVAL_MS = 30_000; // 30 seconds
 
 function stroopsToXlm(stroops: bigint): string {
   const whole = stroops / STROOPS_PER_XLM;
@@ -241,6 +244,47 @@ export default function UserDashboardPage() {
     }
     fetchAll();
   }, [address, fetchAll]);
+
+  // Poll individual meter balances every 30s for live updates
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!address || meterIds.length === 0) {
+      if (pollRef.current) clearInterval(pollRef.current);
+      return;
+    }
+
+    async function pollBalances() {
+      for (const id of meterIds) {
+        try {
+          const res = await fetch(`${API}/api/meters/${id}/balance`);
+          if (!res.ok) continue;
+          const data = await res.json();
+          setMeters((prev) => {
+            const existing = prev[id];
+            if (!existing) return prev;
+            return {
+              ...prev,
+              [id]: {
+                ...existing,
+                balance: BigInt(data.balance ?? existing.balance),
+                units_used: data.units_used ?? existing.units_used,
+                active: data.active ?? existing.active,
+              },
+            };
+          });
+        } catch {
+          // Silently skip — full refresh will recover
+        }
+      }
+      setLastRefresh(new Date());
+    }
+
+    pollRef.current = setInterval(pollBalances, BALANCE_POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [address, meterIds]);
 
   return (
     <>


### PR DESCRIPTION
closes #224 
closes #223
closes #222
closes #221



I have completed all the requested tasks. I created the branch fix/backend-reliability-improvements, implemented each issue in its own isolated commit, and pushed it to your GitHub repository without testing or compiling the code.

Here is a summary of the commits that were made:

1. Issue 1: Admin Meter Deactivation (a7fe11a)

Added the deactivate_meter function to the Soroban smart contract, which unconditionally sets meter.active = false and emits the deactivation events.
Added the POST /api/meters/:id/deactivate admin route in the backend API to invoke this contract function.
Updated the Provider Dashboard table to include an "Actions" column with a wired "Deactivate" button that triggers a toast notification with the transaction hash upon success.
2. Issue 2: Request Timeout Middleware (71cf135)

Installed connect-timeout (and its types).
Configured a 15-second default timeout (adjustable via the REQUEST_TIMEOUT env variable) early in the Express middleware chain in index.ts.
Added a timeout-specific error handler that immediately returns a 504 status while logging the method, path, and duration of the timed-out request.
Updated .env.example.
3. Issue 3: Dedicated Balance Endpoint & Polling (1fda790)

Added a GET /api/meters/:id/balance route to directly read meter status, implementing a 5-second in-memory cache to reduce the load on the Stellar RPC.
Refactored the User Dashboard to poll individual meter balances every 30 seconds using this new endpoint and updating React state silently, cleaning up the interval when unmounted.
Documented the new endpoint structure in README.md.
4. Issue 4: MQTT Reconnect with Exponential Backoff (0ecbb74)

Configured the MQTT client in the IoT bridge with connection timeouts and exponential backoff during reconnect events (capped at 30 seconds).
Integrated logging for each reconnection attempt and configured it to halt if attempts exceed the limit (customizable via MQTT_MAX_RECONNECT_ATTEMPTS in the .env.example).
Reset the attempt counter back to 0 on successful connect events.