### PR TITLE
fix: resolve issues #287, #288, #291, #292

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -1,0 +1,27 @@
+backend:
+  - changed-files:
+    - any-glob-to-any-file: 'backend/**'
+
+frontend:
+  - changed-files:
+    - any-glob-to-any-file: 'frontend/**'
+
+contract:
+  - changed-files:
+    - any-glob-to-any-file: 'contracts/**'
+
+infra:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docker-compose.yml'
+      - '**/Dockerfile'
+      - '.github/workflows/**'
+      - 'nginx.conf'
+      - 'mosquitto.conf'
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'README.md'
+      - 'docs/**'
+      - 'CONTRIBUTING.md'

--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,17 @@
+name: PR Labeller
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeller.yml

--- a/backend/src/lib/stellar.ts
+++ b/backend/src/lib/stellar.ts
@@ -30,10 +30,10 @@ export const scrub = (msg: string | undefined): string => {
 };
 
 export class StellarService {
-  server: StellarSdk.SorobanRpc.Server;
-  adminKeypair: StellarSdk.Keypair;
-  contractId: string;
-  networkPassphrase: string;
+  public readonly server: StellarSdk.SorobanRpc.Server;
+  public readonly adminKeypair: StellarSdk.Keypair;
+  public readonly contractId: string;
+  public readonly networkPassphrase: string;
 
   constructor(config: { rpcUrl: string; adminSecret: string; contractId: string; network: string }) {
     this.server = new StellarSdk.SorobanRpc.Server(config.rpcUrl);

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -202,5 +202,3 @@ export function createMeterRouter(stellar: StellarService) {
   return meterRouter;
 }
 
-// Default export for back-compat with index.ts
-export const meterRouter = createMeterRouter(stellarService);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,21 @@ services:
     networks:
       - app-network
 
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        - VITE_CONTRACT_ID=${VITE_CONTRACT_ID}
+        - VITE_BACKEND_URL=${VITE_BACKEND_URL}
+        - VITE_RPC_URL=${VITE_RPC_URL}
+        - VITE_NETWORK_PASSPHRASE=${VITE_NETWORK_PASSPHRASE}
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    networks:
+      - app-network
+
 networks:
   app-network:
     driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,30 @@
+# --- Builder stage ---
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+ARG VITE_CONTRACT_ID
+ARG VITE_BACKEND_URL
+ARG VITE_RPC_URL
+ARG VITE_NETWORK_PASSPHRASE
+
+ENV VITE_CONTRACT_ID=$VITE_CONTRACT_ID
+ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
+ENV VITE_RPC_URL=$VITE_RPC_URL
+ENV VITE_NETWORK_PASSPHRASE=$VITE_NETWORK_PASSPHRASE
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# --- Runner stage ---
+FROM nginx:alpine AS runner
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary

- **#287** `frontend/Dockerfile` — multi-stage build (node builder + nginx runner) with all four `VITE_CONTRACT_ID`, `VITE_BACKEND_URL`, `VITE_RPC_URL`, `VITE_NETWORK_PASSPHRASE` declared as `ARG`/`ENV`; repo `nginx.conf` used for SPA routing; `docker-compose.yml` updated with `frontend` service passing all four build-args.
- **#288** `.github/labeller.yml` + `.github/workflows/labeller.yml` — path-based PR labeller using `actions/labeler@v5` that auto-applies `backend`, `frontend`, `contract`, `infra`, `documentation` labels on pull_request events.
- **#291** `backend/src/routes/meters.ts` — removed stray `export const meterRouter = createMeterRouter(stellarService)` at bottom of file; `index.ts` already uses `createMeterRouter` directly.
- **#292** `backend/src/lib/stellar.ts` — declared `server`, `contractId`, `adminKeypair`, and `networkPassphrase` as `public readonly` on `StellarService`.

## Test plan
- [ ] `docker compose build frontend` succeeds with no warnings
- [ ] Frontend SPA routes (e.g. `/dashboard`) serve `index.html` via nginx
- [ ] PRs touching `backend/**` receive the `backend` label automatically
- [ ] `npm run build` in `backend/` passes with no TypeScript errors
- [ ] `POST /api/meters` returns correct response on first request (no need to hit `/history` first)

Closes #287, closes #288, closes #291, closes #292