### PR TITLE
fix(backend): resolve issues #265, #266, #267, #268

### DIFF
--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -14,6 +14,42 @@ const BALANCE_CACHE_TTL_MS = 5_000; // 5-second cache to reduce RPC load
 export function createMeterRouter(stellar: StellarService) {
   const meterRouter = Router();
 
+  /**
+   * GET /api/meters?page=1&pageSize=25 — list all meters with pagination
+   *
+   * Registered BEFORE /:id so the literal string "meters" is never matched
+   * as a meter ID parameter.
+   *
+   * Fixes #268.
+   */
+  meterRouter.get(
+    "/",
+    asyncHandler(async (req, res) => {
+      const page = Math.max(1, Number(req.query.page ?? 1) || 1);
+      const pageSize = Math.min(
+        100,
+        Math.max(1, Number(req.query.pageSize ?? 25) || 25),
+      );
+
+      const result = await stellar.query("get_all_meters", []);
+      const allMeters = (StellarSdk.scValToNative(result) as any[]) ?? [];
+
+      const total = allMeters.length;
+      const start = (page - 1) * pageSize;
+      const meters = allMeters.slice(start, start + pageSize);
+
+      res.json({
+        meters,
+        pagination: {
+          page,
+          pageSize,
+          total,
+          pages: Math.ceil(total / pageSize),
+        },
+      });
+    }),
+  );
+
   /** GET /api/meters/export?format=csv|json — download all meter data */
   meterRouter.get(
     "/export",

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import * as crypto from "crypto";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { adminInvoke, contractQuery } from "../lib/stellar.js";
+import { adminInvoke } from "../lib/stellar.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
 import { validateRequest } from "../lib/validation.js";
 import { logger } from "../lib/logger.js";


### PR DESCRIPTION
#265 - GET /api/meters/export already uses stellar.query() correctly via the StellarService instance injected through createMeterRouter(stellar). Confirmed contractQuery is not referenced anywhere in meters.ts.

#266 - backend/src/routes/payments.ts exists and exports paymentsRouter; no module-not-found crash on startup.

#267 - backend/src/routes/webhooks.ts exists and exports webhookRouter; removed stale contractQuery import that was imported but unused, matching the same pattern that caused #265 and would have thrown ReferenceError if ever invoked directly.

#268 - Add GET /api/meters with pagination support. Route is registered before GET /:id to prevent the literal path segment being matched as a meter ID parameter. Calls stellar.query('get_all_meters', []) and returns paginated results with page/pageSize/total/pages metadata.

closes #265 
closes #266 
closes #267 closes #268 