### PR TITLE
feat: oracle audit trail, revenue summary, atomic distribution, and meter activate/deactivate endpoints

### DIFF
--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -102,8 +102,6 @@ export function createMeterRouter(stellar: StellarService) {
     requireAdminKey,
     asyncHandler(async (req, res) => {
       const meterId = req.params.id;
-
-      // Verify meter exists first
       try {
         await stellar.query("get_meter", [
           StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
@@ -111,15 +109,32 @@ export function createMeterRouter(stellar: StellarService) {
       } catch {
         return res.status(404).json({ error: "Meter not found" });
       }
+      const hash = await stellar.invoke("set_active", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        StellarSdk.nativeToScVal(false, { type: "bool" }),
+      ]);
+      res.json({ hash, meter_id: meterId, active: false });
+    }),
+  );
 
+  /** POST /api/meters/:id/activate — admin manually activates a meter */
+  meterRouter.post(
+    "/:id/activate",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const meterId = req.params.id;
       try {
-        const txHash = await stellar.invoke("deactivate_meter", [
+        await stellar.query("get_meter", [
           StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
         ]);
-        res.json({ success: true, tx_hash: txHash, meter_id: meterId });
-      } catch (err: any) {
-        res.status(500).json({ error: err.message });
+      } catch {
+        return res.status(404).json({ error: "Meter not found" });
       }
+      const hash = await stellar.invoke("set_active", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        StellarSdk.nativeToScVal(true, { type: "bool" }),
+      ]);
+      res.json({ hash, meter_id: meterId, active: true });
     }),
   );
 

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -316,9 +316,15 @@ impl SolarGridContract {
     }
 
     /// Register the IoT oracle address. Only admin may call this.
+    /// Emits `ora_set` event with (old_oracle, new_oracle) for audit trail.
     pub fn set_oracle(env: Env, oracle: Address) -> Result<(), ContractError> {
         Self::require_admin(&env)?;
+        let old_oracle: Option<Address> = env.storage().instance().get(&ORACLE);
         env.storage().instance().set(&ORACLE, &oracle);
+        env.events().publish(
+            (EVT_NS, symbol_short!("ora_set")),
+            (old_oracle, oracle),
+        );
         Ok(())
     }
 
@@ -326,6 +332,15 @@ impl SolarGridContract {
     pub fn get_oracle(env: Env) -> Result<Option<Address>, ContractError> {
         Self::require_initialized(&env)?;
         Ok(env.storage().instance().get(&ORACLE))
+    }
+
+    /// Explicitly clear the oracle address. Only admin may call this.
+    /// Emits `ora_clr` event.
+    pub fn remove_oracle(env: Env) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        env.storage().instance().remove(&ORACLE);
+        env.events().publish((EVT_NS, symbol_short!("ora_clr")), ());
+        Ok(())
     }
 
     /// Make a payment to top up a meter's balance and activate it.
@@ -461,6 +476,22 @@ impl SolarGridContract {
         Self::require_initialized(&env)?;
         let provider_key = DataKey::ProviderRevenue(provider);
         Ok(env.storage().persistent().get(&provider_key).unwrap_or(0))
+    }
+
+    /// Return revenue balances for the admin and all collaborators. Admin-only.
+    pub fn get_revenue_summary(env: Env) -> Result<Map<Address, i128>, ContractError> {
+        Self::require_admin(&env)?;
+        let collabs: Vec<Address> = env.storage().instance().get(&COLLABS).unwrap_or(Vec::new(&env));
+        let admin = Self::get_admin(&env)?;
+
+        let mut result: Map<Address, i128> = Map::new(&env);
+        let admin_key = DataKey::ProviderRevenue(admin.clone());
+        result.set(admin.clone(), env.storage().persistent().get(&admin_key).unwrap_or(0));
+        for c in collabs.iter() {
+            let key = DataKey::ProviderRevenue(c.clone());
+            result.set(c, env.storage().persistent().get(&key).unwrap_or(0));
+        }
+        Ok(result)
     }
 
     /// Check whether a meter currently has active energy access.
@@ -683,6 +714,28 @@ impl SolarGridContract {
             result.set(collaborator, payout);
         }
         Ok(result)
+    }
+
+    /// Distribute `amount` stroops and perform the actual token transfers atomically.
+    /// Uses `distribute` internally to compute shares, then transfers to each collaborator.
+    /// Emits `distrib` event after all transfers succeed.
+    pub fn distribute_and_transfer(env: Env, amount: i128) -> Result<Map<Address, i128>, ContractError> {
+        Self::require_admin(&env)?;
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let token_address = Self::get_token_address(&env)?;
+        let token = token::Client::new(&env, &token_address);
+
+        let payouts = Self::distribute(env.clone(), amount)?;
+        for (collaborator, payout) in payouts.iter() {
+            if payout > 0 {
+                token.transfer(&env.current_contract_address(), &collaborator, &payout);
+            }
+        }
+        env.events().publish((EVT_NS, symbol_short!("distrib")), (amount,));
+        Ok(payouts)
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR resolves four feature requests across the contract and backend layers.

---

### #351 — `feat(contract)`: add `update_oracle` with event emission and `remove_oracle`

**File:** `contracts/solar_grid/src/lib.rs`

- Updated `set_oracle` to capture the existing oracle address before overwriting it and emit an `ora_set` event carrying `(old_oracle, new_oracle)`, providing a full on-chain audit trail for oracle rotations.
- Added `remove_oracle` (admin-only) that explicitly clears the oracle from instance storage and emits an `ora_clr` event, giving providers a safe way to revoke oracle access without a replacement address.

---

### #352 — `feat(contract)`: add `get_revenue_summary` to return revenue for any provider address

**File:** `contracts/solar_grid/src/lib.rs`

- Added `get_revenue_summary` (admin-only) that reads `ProviderRevenue` storage for the admin address and every address present in the `COLLABS` list, returning a single `Map<Address, i128>`.
- Eliminates the need for N separate `get_provider_revenue` calls in multi-collaborator setups, making audit and reconciliation straightforward.

---

### #350 — `feat(contract)`: add `distribute_and_transfer` to atomically pay out collaborator shares

**File:** `contracts/solar_grid/src/lib.rs`

- Added `distribute_and_transfer` (admin-only) that internally calls `distribute` to compute each collaborator's payout share, then iterates the result and calls `token.transfer` for every collaborator with a non-zero payout.
- Because all transfers occur within a single Soroban transaction, the operation is atomic — any failed transfer reverts the entire call.
- Emits a `distrib` event after all transfers succeed.
- Reuses existing `distribute` logic to avoid duplication.

---

### #349 — `feat(backend)`: add `POST /api/meters/:id/deactivate` and `POST /api/meters/:id/activate`

**File:** `backend/src/routes/meters.ts`

- Updated `POST /api/meters/:id/deactivate` to invoke `set_active(id, false)` on the contract (previously called `deactivate_meter`), aligning the endpoint with the symmetric activate/deactivate API.
- Added `POST /api/meters/:id/activate` that invokes `set_active(id, true)`.
- Both endpoints require the `X-Admin-Key` header (`requireAdminKey` middleware).
- Both perform a preflight `get_meter` query and return `404` if the meter does not exist.
- Response shape: `{ hash, meter_id, active: boolean }`.

---

## Files Changed

| File | Changes |
|------|---------|
| `contracts/solar_grid/src/lib.rs` | `set_oracle` updated; `remove_oracle`, `get_revenue_summary`, `distribute_and_transfer` added |
| `backend/src/routes/meters.ts` | `deactivate` updated to use `set_active`; `activate` endpoint added |

---

Closes #349
Closes #350
Closes #351
Closes #352