### PR TITLE
feat(contract): emit events, admin transfer, batch register, and combined meter query

### DIFF
--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -375,6 +375,16 @@ async function handleContractEvent(
         break;
       }
 
+      case "solargrid:lmt_set": {
+        const [oldLimit, newLimit] = StellarSdk.scValToNative(event.value) as [bigint, bigint];
+        logger.info("lmt_set contract event", {
+          meterId: subject,
+          oldLimit: Number(oldLimit),
+          newLimit: Number(newLimit),
+        });
+        break;
+      }
+
       default:
         break;
     }

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -147,6 +147,14 @@ pub enum DataKey {
     MeterBalance(String),
 }
 
+/// Combined view returned by get_meter_full — meter state plus its balance
+/// in a single query, eliminating the need for two separate RPC calls.
+#[contracttype]
+pub struct MeterView {
+    pub meter: Meter,
+    pub balance: i128,
+}
+
 // ── Event topics (contract namespace) ────────────────────────────────────────
 
 const EVT_NS: Symbol = symbol_short!("solargrid");
@@ -537,6 +545,15 @@ impl SolarGridContract {
     pub fn get_meter(env: Env, meter_id: String) -> Result<Meter, ContractError> {
         let key = DataKey::Meter(meter_id);
         Self::get_meter_or_error(&env, &key)
+    }
+
+    /// Get meter state and balance in one query.
+    pub fn get_meter_full(env: Env, meter_id: String) -> Result<MeterView, ContractError> {
+        let key = DataKey::Meter(meter_id.clone());
+        let meter = Self::get_meter_or_error(&env, &key)?;
+        let bal_key = DataKey::MeterBalance(meter_id);
+        let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        Ok(MeterView { meter, balance })
     }
 
     /// Admin can manually toggle meter access (e.g. maintenance).

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -686,6 +686,74 @@ impl SolarGridContract {
         Ok(result)
     }
 
+    /// Register up to 50 meters in a single transaction.
+    /// Skips meters whose owner is not allowlisted or that already exist,
+    /// emitting a reg_skip event for each. Updates OwnerMeters and METER_LIST indexes.
+    pub fn batch_register_meters(
+        env: Env,
+        meters: Vec<(String, Address)>,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        if meters.len() > 50 {
+            return Err(ContractError::BatchTooLarge);
+        }
+        let allowlist = Self::get_allowlist(env.clone())?;
+        for (meter_id, owner) in meters.iter() {
+            if !allowlist.contains(&owner) {
+                env.events().publish(
+                    (EVT_NS, symbol_short!("reg_skip"), meter_id.clone()),
+                    owner.clone(),
+                );
+                continue;
+            }
+            let key = DataKey::Meter(meter_id.clone());
+            if env.storage().persistent().has(&key) {
+                env.events().publish(
+                    (EVT_NS, symbol_short!("reg_skip"), meter_id.clone()),
+                    owner.clone(),
+                );
+                continue;
+            }
+            let now = env.ledger().timestamp();
+            let meter = Meter {
+                version: 2,
+                owner: owner.clone(),
+                active: false,
+                units_used: 0,
+                plan: PaymentPlan::Daily,
+                last_payment: now,
+                expires_at: now,
+                daily_limit: 0,
+                day_spent: 0,
+                day_start: now,
+            };
+            env.storage().persistent().set(&key, &meter);
+
+            let owner_key = DataKey::OwnerMeters(owner.clone());
+            let mut list: Vec<String> = env
+                .storage()
+                .persistent()
+                .get(&owner_key)
+                .unwrap_or_else(|| vec![&env]);
+            list.push_back(meter_id.clone());
+            env.storage().persistent().set(&owner_key, &list);
+
+            let mut global_list: Vec<String> = env
+                .storage()
+                .instance()
+                .get(&METER_LIST)
+                .unwrap_or_else(|| vec![&env]);
+            global_list.push_back(meter_id.clone());
+            env.storage().instance().set(&METER_LIST, &global_list);
+
+            env.events().publish(
+                (EVT_NS, symbol_short!("mtr_reg"), meter_id.clone()),
+                owner.clone(),
+            );
+        }
+        Ok(())
+    }
+
     /// Propose a new admin address. Current admin only.
     /// The transfer is completed only when the new address calls accept_admin.
     pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -36,6 +36,7 @@ const ORACLE: Symbol = symbol_short!("ORACLE");
 const METER_LIST: Symbol = symbol_short!("MLIST");
 const COLLABS: Symbol = symbol_short!("COLLABS");
 const SHARES: Symbol = symbol_short!("SHARES");
+const PENDING_ADMIN: Symbol = symbol_short!("PADMIN");
 const SECONDS_PER_DAY: u64 = 86_400;
 const SECONDS_PER_WEEK: u64 = 604_800;
 
@@ -683,6 +684,29 @@ impl SolarGridContract {
             result.set(collaborator, payout);
         }
         Ok(result)
+    }
+
+    /// Propose a new admin address. Current admin only.
+    /// The transfer is completed only when the new address calls accept_admin.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        env.storage().instance().set(&PENDING_ADMIN, &new_admin);
+        env.events().publish((EVT_NS, symbol_short!("adm_prop")), new_admin);
+        Ok(())
+    }
+
+    /// Accept an in-flight admin transfer. Must be called by the pending admin.
+    pub fn accept_admin(env: Env) -> Result<(), ContractError> {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN)
+            .ok_or(ContractError::Unauthorized)?;
+        pending.require_auth();
+        env.storage().instance().set(&ADMIN, &pending);
+        env.storage().instance().remove(&PENDING_ADMIN);
+        env.events().publish((EVT_NS, symbol_short!("adm_set")), pending);
+        Ok(())
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -823,8 +823,13 @@ impl SolarGridContract {
         }
         let key = DataKey::Meter(meter_id.clone());
         let mut meter = Self::get_meter_or_error(&env, &key)?;
+        let old_limit = meter.daily_limit;
         meter.daily_limit = limit;
         env.storage().persistent().set(&key, &meter);
+        env.events().publish(
+            (EVT_NS, symbol_short!("lmt_set"), meter_id),
+            (old_limit, limit),
+        );
         Ok(())
     }
 

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -84,17 +84,11 @@ export const client = new ContractClient(
 );
 
 export async function fetchMeter(meterId: string): Promise<MeterData> {
-  const meterRetval = await client.query("get_meter", [
+  const retval = await client.query("get_meter_full", [
     StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
   ]);
-  const meterData = StellarSdk.scValToNative(meterRetval);
-
-  const balanceRetval = await client.query("get_meter_balance", [
-    StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
-  ]);
-  const balance = StellarSdk.scValToNative(balanceRetval);
-
-  return { ...meterData, balance: BigInt(balance) } as MeterData;
+  const view = StellarSdk.scValToNative(retval) as { meter: Omit<MeterData, "balance">; balance: bigint };
+  return { ...view.meter, balance: view.balance } as MeterData;
 }
 
 export async function contractInvoke(


### PR DESCRIPTION
## Summary

This PR implements four independent features across the Soroban smart contract, IoT bridge, and frontend contract client.

---

### #355 — Emit `lmt_set` event when `set_daily_limit` is called

**File:** `contracts/solar_grid/src/lib.rs`

`set_daily_limit` previously updated `meter.daily_limit` silently with no observable on-chain signal. The IoT bridge and backend had no way to detect limit changes without polling every meter.

**Changes:**
- Captures `old_limit` before overwriting the field.
- Publishes a `(solargrid, lmt_set, meter_id)` event with `(old_limit, new_limit)` as the data payload.

**File:** `backend/src/iot/bridge.ts`

- Added a `solargrid:lmt_set` case in `handleContractEvent` that decodes the `(old_limit, new_limit)` tuple and logs the change, serving as the hook for any future cache invalidation logic.

Closes #355

---

### #353 — Add `propose_admin` / `accept_admin` for safe admin transfer

**File:** `contracts/solar_grid/src/lib.rs`

The admin address was set at deployment with no migration path. A compromised or rotated keypair had no on-chain remedy.

**Changes:**
- Added `PENDING_ADMIN` (`"PADMIN"`) instance-storage key.
- `propose_admin(new_admin)` — callable only by the current admin; stores the candidate and emits `adm_prop`.
- `accept_admin()` — callable only by the pending admin (enforced via `require_auth`); promotes the pending address to `ADMIN`, removes `PENDING_ADMIN`, and emits `adm_set`.

The two-step pattern prevents accidental lockout: the transfer is not final until the new address explicitly accepts.

Closes #353

---

### #356 — Add `batch_register_meters` for efficient bulk onboarding

**File:** `contracts/solar_grid/src/lib.rs`

Registering meters one-at-a-time is impractical when onboarding an installation site with 10–50 meters.

**Changes:**
- `batch_register_meters(meters: Vec<(String, Address)>)` — admin-only, max 50 entries per call (`BatchTooLarge` otherwise).
- Each entry is validated against the allowlist and checked for duplicate registration; skipped entries emit a `reg_skip` event.
- Successfully registered entries follow the same `Meter` v2 initialisation as `register_meter`, and update both the `OwnerMeters` persistent index and the global `METER_LIST` instance index.
- Emits `mtr_reg` for every successfully registered meter.

Closes #356

---

### #354 — Add `MeterView` / `get_meter_full` for single-query meter fetch

**File:** `contracts/solar_grid/src/lib.rs`

The frontend called `get_meter` and `get_meter_balance` in two sequential RPC round-trips to build a complete meter view.

**Changes:**
- Added `MeterView { meter: Meter, balance: i128 }` contract type.
- `get_meter_full(meter_id)` loads both fields from persistent storage and returns the combined struct in one call.

**File:** `frontend/src/lib/contract.ts`

- `fetchMeter` now calls `get_meter_full` instead of the two separate queries, destructuring the nested `{ meter, balance }` response into the flat `MeterData` shape expected by callers.

Closes #354

---

## Files changed

| File | Description |
|------|-------------|
| `contracts/solar_grid/src/lib.rs` | `lmt_set` event, `PENDING_ADMIN`, `propose_admin`, `accept_admin`, `MeterView`, `get_meter_full`, `batch_register_meters` |
| `backend/src/iot/bridge.ts` | `solargrid:lmt_set` event handler |
| `frontend/src/lib/contract.ts` | `fetchMeter` updated to use `get_meter_full` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)