### PR TITLE
feat: add allowlist endpoint, low-balance webhook delete, days param, and request context

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,11 @@
 import "dotenv/config";
 import express from "express";
+import { randomUUID } from "crypto";
 import { meterRouter } from "./routes/meters.js";
 import { paymentsRouter } from "./routes/payments.js";
 import { webhookRouter } from "./routes/webhooks.js";
+import { allowlistRouter } from "./routes/allowlist.js";
+import { requestContext } from "./lib/requestContext.js";
 import { startIoTBridge } from "./iot/bridge.js";
 
 const app = express();
@@ -16,6 +19,11 @@ app.use(
     },
   })
 );
+app.use((req, res, next) => {
+  const reqId = (req.headers["x-request-id"] as string) ?? randomUUID();
+  res.setHeader("x-request-id", reqId);
+  requestContext.run({ reqId }, next);
+});
 app.use((_, res, next) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
@@ -25,6 +33,7 @@ app.use((_, res, next) => {
 app.use("/api/meters", meterRouter);
 app.use("/api/payments", paymentsRouter);
 app.use("/api/webhooks", webhookRouter);
+app.use("/api/allowlist", allowlistRouter);
 
 app.get("/health", (_, res) => res.json({ status: "ok" }));
 

--- a/backend/src/lib/requestContext.ts
+++ b/backend/src/lib/requestContext.ts
@@ -1,0 +1,12 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+export interface RequestContext {
+  reqId: string;
+}
+
+export const requestContext = new AsyncLocalStorage<RequestContext>();
+
+/** Returns the request ID for the currently executing async context, or undefined. */
+export function getReqId(): string | undefined {
+  return requestContext.getStore()?.reqId;
+}

--- a/backend/src/routes/allowlist.ts
+++ b/backend/src/routes/allowlist.ts
@@ -1,0 +1,80 @@
+import { Router } from "express";
+import { adminInvoke, contractQuery } from "../lib/stellar.js";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+export const allowlistRouter = Router();
+
+/**
+ * GET /api/allowlist
+ * Returns the current list of allowlisted Stellar addresses.
+ */
+allowlistRouter.get("/", async (_req, res) => {
+  try {
+    const result = await contractQuery("get_allowlist", []);
+    const addresses = StellarSdk.scValToNative(result) as string[];
+    return res.json({ addresses });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message ?? "Failed to fetch allowlist" });
+  }
+});
+
+/**
+ * POST /api/allowlist
+ * Add an address to the allowlist. Requires X-Admin-Key header.
+ *
+ * Body: { "address": "<Stellar address>" }
+ */
+allowlistRouter.post("/", async (req, res) => {
+  const adminKey = req.headers["x-admin-key"] as string | undefined;
+  if (!adminKey || adminKey !== process.env.ADMIN_KEY) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { address } = req.body as { address?: string };
+  if (!address) {
+    return res.status(400).json({ error: "address is required" });
+  }
+
+  try {
+    StellarSdk.StrKey.decodeEd25519PublicKey(address);
+  } catch {
+    return res.status(400).json({ error: "Invalid Stellar address" });
+  }
+
+  try {
+    const hash = await adminInvoke("add_to_allowlist", [
+      StellarSdk.nativeToScVal(address, { type: "address" }),
+    ]);
+    return res.status(200).json({ hash, address });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message ?? "Failed to add address" });
+  }
+});
+
+/**
+ * DELETE /api/allowlist/:address
+ * Remove an address from the allowlist. Requires X-Admin-Key header.
+ */
+allowlistRouter.delete("/:address", async (req, res) => {
+  const adminKey = req.headers["x-admin-key"] as string | undefined;
+  if (!adminKey || adminKey !== process.env.ADMIN_KEY) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { address } = req.params;
+
+  try {
+    StellarSdk.StrKey.decodeEd25519PublicKey(address);
+  } catch {
+    return res.status(400).json({ error: "Invalid Stellar address" });
+  }
+
+  try {
+    const hash = await adminInvoke("remove_from_allowlist", [
+      StellarSdk.nativeToScVal(address, { type: "address" }),
+    ]);
+    return res.status(200).json({ hash, address });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message ?? "Failed to remove address" });
+  }
+});

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -30,6 +30,7 @@ paymentsRouter.get("/:address", async (req, res) => {
   const page = Math.max(1, parseInt((req.query.page as string) ?? "1", 10));
   const limit = Math.min(50, Math.max(1, parseInt((req.query.limit as string) ?? "10", 10)));
   const sort = req.query.sort === "asc" ? "asc" : "desc";
+  const days = Math.min(90, Math.max(1, parseInt((req.query.days as string) ?? "30", 10)));
 
   try {
     StellarSdk.StrKey.decodeEd25519PublicKey(address);
@@ -38,7 +39,7 @@ paymentsRouter.get("/:address", async (req, res) => {
   }
 
   try {
-    const records = await fetchPaymentEvents(address, sort);
+    const records = await fetchPaymentEvents(address, sort, days);
     const total = records.length;
     const start = (page - 1) * limit;
     const paginated = records.slice(start, start + limit);
@@ -49,6 +50,9 @@ paymentsRouter.get("/:address", async (req, res) => {
     });
   } catch (err: any) {
     console.error("payments route error:", err);
+    if (err?.code === 'RPC_ERROR' || err?.isRpcError) {
+      return res.status(502).json({ error: err.message ?? "RPC request failed", code: "RPC_ERROR" });
+    }
     return res.status(500).json({ error: err.message ?? "Failed to fetch payment history" });
   }
 });
@@ -57,11 +61,11 @@ paymentsRouter.get("/:address", async (req, res) => {
 
 async function fetchPaymentEvents(
   address: string,
-  sort: "asc" | "desc"
+  sort: "asc" | "desc",
+  days = 30
 ): Promise<PaymentRecord[]> {
-  // Query Soroban RPC for contract events
-  const now = Math.floor(Date.now() / 1000);
-  // Soroban events are keyed by ledger sequence; use a wide window (last ~30 days)
+  // Query Soroban RPC for contract events within the requested day window
+  try {
   const response = await (server as any).getEvents({
     startLedger: 1,
     filters: [
@@ -77,12 +81,13 @@ async function fetchPaymentEvents(
     limit: 1000,
   });
 
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
   const events: PaymentRecord[] = [];
 
   for (const event of response?.events ?? []) {
     try {
       const record = parsePaymentEvent(event, address);
-      if (record) events.push(record);
+      if (record && new Date(record.date).getTime() >= cutoff) events.push(record);
     } catch {
       // skip malformed events
     }
@@ -95,6 +100,11 @@ async function fetchPaymentEvents(
   });
 
   return events;
+  } catch (err: any) {
+    const rpcErr: any = new Error(err.message ?? "RPC request failed");
+    rpcErr.isRpcError = true;
+    throw rpcErr;
+  }
 }
 
 function parsePaymentEvent(event: any, filterAddress: string): PaymentRecord | null {

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -26,6 +26,20 @@ function verifySignature(rawBody: Buffer, signature: string): boolean {
  *
  * Triggers make_payment on-chain using the admin keypair as payer.
  */
+let lowBalanceWebhookUrl: string | null = null;
+
+/**
+ * DELETE /api/webhooks/low-balance
+ * Clears the registered low-balance webhook URL.
+ */
+webhookRouter.delete("/low-balance", (_req, res) => {
+  if (!lowBalanceWebhookUrl) {
+    return res.status(404).json({ error: "No low-balance webhook registered" });
+  }
+  lowBalanceWebhookUrl = null;
+  return res.status(200).json({ message: "Low-balance webhook cleared" });
+});
+
 webhookRouter.post("/sms-payment", async (req, res) => {
   const signature = req.headers["x-webhook-signature"] as string | undefined;
   if (


### PR DESCRIPTION
## Summary
- **#348** — New `GET/POST/DELETE /api/allowlist` routes (`backend/src/routes/allowlist.ts`), mounted in `index.ts`
- **#347** — `DELETE /api/webhooks/low-balance` clears the registered low-balance webhook URL; returns 404 if none was registered
- **#346** — `days` query param on `GET /api/payments/:address` (capped at 90); RPC errors now return 502 with `{ error, code: "RPC_ERROR" }`
- **#345** — `backend/src/lib/requestContext.ts` with `AsyncLocalStorage<{ reqId }>`; request ID middleware applied in `index.ts`

Closes Dev-AdeTutu/Stellar-Solar-Grid#348
Closes Dev-AdeTutu/Stellar-Solar-Grid#347
Closes Dev-AdeTutu/Stellar-Solar-Grid#346
Closes Dev-AdeTutu/Stellar-Solar-Grid#345