### PR TITLE
fix: clipboard fallback, collaborators route, migrate_meter version check, workflow Node 22

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: backend/package-lock.json
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: cd frontend && npm ci && npm run build
+    env:
+      VITE_CONTRACT_ID: placeholder
+      VITE_RPC_URL: https://soroban-testnet.stellar.org
+      VITE_NETWORK_PASSPHRASE: Test SDF Network ; September 2015
 
   backend:
     runs-on: ubuntu-latest
@@ -31,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: cd backend && npm ci
       - run: cd backend && npm run build
       - name: Run e2e tests (only when secrets are available)

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci

--- a/backend/src/routes/collaborators.ts
+++ b/backend/src/routes/collaborators.ts
@@ -10,12 +10,12 @@ export interface CollaboratorShare {
 }
 
 /**
- * GET /api/collaborators/:contractId
+ * GET /api/collaborators
  *
  * Returns all collaborators and their shares in a single RPC simulation
  * of get_all_shares — eliminates the previous N+1 per-collaborator calls.
  */
-collaboratorRouter.get("/:contractId", async (req, res) => {
+collaboratorRouter.get("/", async (req, res) => {
   try {
     const raw = await contractQuery("get_all_shares", []);
     const shareMap = StellarSdk.scValToNative(raw) as Record<string, number>;

--- a/contracts/solar_grid/src/lib.rs
+++ b/contracts/solar_grid/src/lib.rs
@@ -832,7 +832,13 @@ impl SolarGridContract {
     /// Admin-only. Use migrate_meter_to_v2 for v1 → v2 migrations.
     pub fn migrate_meter(env: Env, meter_id: String) -> Result<(), ContractError> {
         Self::require_admin(&env)?;
-        let key = DataKey::Meter(meter_id);
+        let key = DataKey::Meter(meter_id.clone());
+        // Already at v2 — idempotent no-op.
+        if let Some(meter) = env.storage().persistent().get::<DataKey, Meter>(&key) {
+            if meter.version >= 2 {
+                return Ok(());
+            }
+        }
         let legacy: LegacyMeter = env
             .storage()
             .persistent()
@@ -846,7 +852,13 @@ impl SolarGridContract {
     /// Migrate a meter from v1 (LegacyMeterV1) to v2 (Meter) schema. Admin-only.
     pub fn migrate_meter_to_v2(env: Env, meter_id: String) -> Result<(), ContractError> {
         Self::require_admin(&env)?;
-        let key = DataKey::Meter(meter_id);
+        let key = DataKey::Meter(meter_id.clone());
+        // Already at v2 — idempotent no-op.
+        if let Some(meter) = env.storage().persistent().get::<DataKey, Meter>(&key) {
+            if meter.version >= 2 {
+                return Ok(());
+            }
+        }
         let legacy: LegacyMeterV1 = env
             .storage()
             .persistent()
@@ -1806,15 +1818,35 @@ mod tests {
         // Run the migration.
         client.migrate_meter(&meter_id);
 
-        // The entry should now deserialize as a v1 Meter.
+        // The entry should now deserialize as a v2 Meter.
         let meter = client.get_meter(&meter_id);
-        assert_eq!(meter.version, 1);
+        assert_eq!(meter.version, 2);
         assert_eq!(meter.owner, owner);
         assert!(meter.active);
         assert_eq!(meter.units_used, 42);
         assert_eq!(meter.plan, PaymentPlan::UsageBased);
         assert_eq!(meter.last_payment, 1_000);
         assert_eq!(meter.expires_at, u64::MAX);
+    }
+
+    /// Calling migrate_meter on an already-migrated v2 meter is idempotent.
+    #[test]
+    fn test_migrate_meter_idempotent_on_v2() {
+        let (env, client, _admin) = setup();
+        let user = Address::generate(&env);
+        let meter_id = symbol_short!("MIG_IDP");
+
+        // Register creates a v2 meter.
+        allowlist_and_register(&client, &meter_id, &user);
+        let before = client.get_meter(&meter_id);
+        assert_eq!(before.version, 2);
+
+        // Calling migrate_meter again must succeed and leave the entry unchanged.
+        client.migrate_meter(&meter_id);
+        let after = client.get_meter(&meter_id);
+        assert_eq!(after.version, 2);
+        assert_eq!(after.owner, before.owner);
+        assert_eq!(after.units_used, before.units_used);
     }
 
     /// get_all_shares returns the full map in one call.

--- a/frontend/src/components/OfflinePaymentModal.tsx
+++ b/frontend/src/components/OfflinePaymentModal.tsx
@@ -20,6 +20,7 @@ const PLANS = [
 
 export default function OfflinePaymentModal({ meterId, onClose }: Props) {
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const exampleMeter = meterId?.trim() || "METER1";
   const exampleSms = `PAY ${exampleMeter} 5 D`;
 
@@ -28,8 +29,23 @@ export default function OfflinePaymentModal({ meterId, onClose }: Props) {
       await navigator.clipboard.writeText(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API unavailable on some low-end browsers — silently ignore
+      return;
+    } catch {}
+    // Fallback for HTTP / low-end browsers
+    const el = document.createElement("textarea");
+    el.value = text;
+    el.style.position = "fixed";
+    el.style.opacity = "0";
+    document.body.appendChild(el);
+    el.focus();
+    el.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(el);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } else {
+      setCopyFailed(true);
     }
   }
 
@@ -110,6 +126,19 @@ export default function OfflinePaymentModal({ meterId, onClose }: Props) {
                 {copied ? "✓ Copied" : "Copy"}
               </button>
             </div>
+            {copyFailed && (
+              <div className="mt-2">
+                <p className="text-xs text-yellow-400 mb-1">Could not copy automatically. Select and copy the text below:</p>
+                <textarea
+                  readOnly
+                  value={exampleSms}
+                  className="w-full rounded-md border border-yellow-500/40 bg-solar-dark px-3 py-2 text-sm text-solar-yellow font-mono resize-none"
+                  rows={2}
+                  onFocus={(e) => e.currentTarget.select()}
+                  aria-label="SMS text to copy manually"
+                />
+              </div>
+            )}
             <p className="mt-1.5 text-xs text-gray-500">
               Send to: <span className="text-solar-yellow font-bold">{SMS_SHORTCODE}</span>
             </p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,8 +9,8 @@ export interface CollaboratorShare {
  * Fetches all collaborators and their shares in a single request.
  * The backend resolves this with one get_all_shares simulation — no N+1.
  */
-export async function getCollaborators(contractId: string): Promise<CollaboratorShare[]> {
-  const res = await fetch(`${API_BASE}/api/collaborators/${contractId}`);
+export async function getCollaborators(): Promise<CollaboratorShare[]> {
+  const res = await fetch(`${API_BASE}/api/collaborators`);
   if (!res.ok) {
     const { error } = (await res.json()) as { error: string };
     throw new Error(error ?? "Failed to fetch collaborators");


### PR DESCRIPTION
## Summary

Fixes #333, #334, #335, #336 and resolves workflow deprecation warnings.

---

### #333 — Clipboard fallback in OfflinePaymentModal

- Added `document.execCommand('copy')` fallback when `navigator.clipboard` is unavailable (HTTP / low-end Android browsers)
- Added `copyFailed` state: when both methods fail, a selectable `<textarea>` is shown so the user can copy manually

### #334 — Collaborators route param removed

- Changed `GET /:contractId` → `GET /` — the param was never used; always queried the singleton contract
- Updated `frontend/src/lib/api.ts` `getCollaborators` to call `/api/collaborators` (no param)

### #335 — migrate_meter idempotency

- Added version check (`>= 2`) to both `migrate_meter` and `migrate_meter_to_v2` — already-migrated entries return `Ok(())` immediately without re-deserialising
- Fixed pre-existing test assertion: post-migration version is `2`, not `1`
- Added `test_migrate_meter_idempotent_on_v2` to verify calling migrate twice on a v2 meter is safe

### #336 — GET /api/meters already exists

- Confirmed `GET /` is registered at line 20 of `meters.ts`, before all `/:id` routes — no code change required

### Workflow fixes

- Upgraded `setup-node` from Node 20 → 22 (LTS) in `ci.yml`, `frontend-ci.yml`, `backend-ci.yml` to eliminate the Node 20 deprecation warning on GitHub Actions runners
- Added `VITE_CONTRACT_ID`, `VITE_RPC_URL`, and `VITE_NETWORK_PASSPHRASE` env vars to the `ci.yml` frontend job so `next build` receives the variables it needs

Closes #333
Closes #334
Closes #335
Closes #336