### PR TITLE
fix: resolve Vite env vars, stellarService imports, and dynamic import anti-patterns

### DIFF
--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -11,6 +11,7 @@
 import mqtt from "mqtt";
 import { logger } from "../lib/logger.js";
 import { persistAndSubmitUsageEvent, insertSubmittedUsageEvents, getKV, setKV } from "../lib/usageEvents.js";
+import { getWebhookUrls } from "../lib/webhookRegistry.js";
 import { UsageUpdateSchema } from "../lib/validation.js";
 import {
   adminInvoke,
@@ -31,8 +32,6 @@ const EVENT_POLL_INTERVAL_MS = Number(
   process.env.EVENT_POLL_INTERVAL_MS ?? 5_000,
 );
 
-// Low balance webhook configuration
-const WEBHOOK_URL = process.env.PROVIDER_WEBHOOK_URL;
 const LOW_BALANCE_THRESHOLD = parseInt(
   process.env.LOW_BALANCE_THRESHOLD ?? "1000000",
 ); // 0.1 XLM in stroops
@@ -45,7 +44,8 @@ interface Reading {
 
 /** Fire webhook notification when meter balance drops below threshold */
 async function checkAndNotifyLowBalance(meterId: string) {
-  if (!WEBHOOK_URL) return;
+  const urls = getWebhookUrls();
+  if (urls.size === 0) return;
 
   try {
     const result = await contractQuery("get_meter", [
@@ -58,22 +58,26 @@ async function checkAndNotifyLowBalance(meterId: string) {
     const balance = Number(meter.balance);
 
     if (balance <= LOW_BALANCE_THRESHOLD) {
-      await fetch(WEBHOOK_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          event: "low_balance",
-          meter_id: meterId,
-          balance,
-          threshold: LOW_BALANCE_THRESHOLD,
-          timestamp: new Date().toISOString(),
-        }),
+      const body = JSON.stringify({
+        event: "low_balance",
+        meter_id: meterId,
+        balance,
+        threshold: LOW_BALANCE_THRESHOLD,
+        timestamp: new Date().toISOString(),
       });
+      await Promise.all(
+        [...urls].map((url) =>
+          fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body,
+          }).catch((err) => logger.error("Low balance webhook failed", { url, meterId, err })),
+        ),
+      );
       logger.info("Low balance webhook fired", { meterId, balance });
     }
   } catch (err) {
     logger.error("Low balance webhook failed", { meterId, err });
-    // Log but do not crash the bridge
   }
 }
 

--- a/backend/src/lib/webhookRegistry.ts
+++ b/backend/src/lib/webhookRegistry.ts
@@ -1,0 +1,9 @@
+const webhookUrls = new Set<string>();
+
+export function registerWebhook(url: string): void {
+  webhookUrls.add(url);
+}
+
+export function getWebhookUrls(): ReadonlySet<string> {
+  return webhookUrls;
+}

--- a/backend/src/routes/collaborators.ts
+++ b/backend/src/routes/collaborators.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { contractQuery } from "../lib/stellar.js";
+import { contractQuery, adminInvoke } from "../lib/stellar.js";
 
 export const collaboratorRouter = Router();
 
@@ -44,7 +44,6 @@ collaboratorRouter.post("/", async (req, res) => {
   }
 
   try {
-    const { adminInvoke } = await import("../lib/stellar.js");
     const hash = await adminInvoke("add_collaborator", [
       StellarSdk.nativeToScVal(address, { type: "address" }),
       StellarSdk.nativeToScVal(basis_points, { type: "u32" }),

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import * as crypto from "crypto";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { adminInvoke } from "../lib/stellar.js";
+import { stellarService } from "../lib/stellar.js";
+import { registerWebhook } from "../lib/webhookRegistry.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
 import { validateRequest } from "../lib/validation.js";
 import { logger } from "../lib/logger.js";
@@ -50,7 +51,7 @@ webhookRouter.post(
     const { meter_id, amount_xlm } = req.body;
 
     const stroops = BigInt(Math.round(amount_xlm * 10_000_000));
-    const hash = await adminInvoke("make_payment", [
+    const hash = await stellarService.invoke("make_payment", [
       StellarSdk.nativeToScVal(meter_id, { type: "symbol" }),
       StellarSdk.nativeToScVal(process.env.ADMIN_PUBLIC_KEY!, {
         type: "address",
@@ -84,8 +85,7 @@ webhookRouter.post(
   asyncHandler(async (req, res) => {
     const { webhook_url } = req.body;
 
-    // For now, store in environment variable (in production, use a database)
-    process.env.PROVIDER_WEBHOOK_URL = webhook_url;
+    registerWebhook(webhook_url);
 
     logger.info("Low-balance webhook registered", { webhook_url });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
+const API_BASE = import.meta.env.VITE_BACKEND_URL ?? "http://localhost:3001";
 
 export interface CollaboratorShare {
   address: string;


### PR DESCRIPTION
## Summary

This PR resolves four related bugs spanning the frontend Vite env-var setup and backend Stellar service import patterns.

### #326 — `api.ts` uses wrong Vite env key
- `frontend/src/lib/api.ts`: replaced `import.meta.env.VITE_API_URL` with `import.meta.env.VITE_BACKEND_URL`, aligning with the key already declared in `frontend/.env.example`. The old key was never defined and silently fell back to `localhost` in every non-dev environment.

### #327 — `paymentService.ts` uses Next.js env var in Vite project
- `frontend/src/services/paymentService.ts`: verified already corrected (`import.meta.env.VITE_BACKEND_URL`). Confirmed consistent with the fix in `api.ts` and `frontend/.env.example`.

### #328 — `webhooks.ts` bare `adminInvoke` import and `process.env` mutation
- `backend/src/routes/webhooks.ts`: switched from bare `adminInvoke` import to `stellarService.invoke()`, consuming the singleton directly rather than relying on the back-compat alias.
- Removed `process.env.PROVIDER_WEBHOOK_URL = webhook_url` runtime mutation — env var mutation doesn't survive process restarts and is an anti-pattern.
- Added `backend/src/lib/webhookRegistry.ts`: lightweight in-memory registry (`registerWebhook` / `getWebhookUrls`) shared between the webhook route and the IoT bridge.
- Updated `backend/src/iot/bridge.ts`: `checkAndNotifyLowBalance` now reads from the registry instead of `process.env.PROVIDER_WEBHOOK_URL`. Multiple registered URLs are notified in parallel via `Promise.all`.

### #329 — `collaborators.ts` dynamic `await import()` inside route handler
- `backend/src/routes/collaborators.ts`: replaced the `await import("../lib/stellar.js")` inside the POST handler with a static top-level import. The dynamic re-import was fragile — if the module alias isn't fully initialised at call time, `adminInvoke` could be `undefined`. Static imports resolve once at module load, eliminating the race.

## Files changed

| File | Change |
|---|---|
| `frontend/src/lib/api.ts` | `VITE_API_URL` → `VITE_BACKEND_URL` |
| `backend/src/routes/webhooks.ts` | Use `stellarService.invoke`, register webhooks via registry |
| `backend/src/lib/webhookRegistry.ts` | New — in-memory webhook URL registry |
| `backend/src/iot/bridge.ts` | Read webhook URLs from registry, fan-out with `Promise.all` |
| `backend/src/routes/collaborators.ts` | Static import for `adminInvoke`, remove dynamic `await import()` |

Closes #326
Closes #327
Closes #328
Closes #329