### PR TITLE
feat(backend): structured error responses and TTL cache middleware

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -123,6 +123,11 @@ app.get("/metrics", async (_req, res) => {
   res.end(await register.metrics());
 });
 
+// 404 catch-all — must come after all routes
+app.use((_req: Request, res: Response) =>
+  res.status(404).json({ error: "Route not found", code: "NOT_FOUND" })
+);
+
 // Timeout error handler — must come before the generic error handler
 app.use((err: any, req: any, res: any, next: any) => {
   if (req.timedout) {
@@ -131,30 +136,25 @@ app.use((err: any, req: any, res: any, next: any) => {
       path: req.path,
       timeout: requestTimeout,
     });
-    return res.status(504).json({ error: 'Request timed out' });
+    return res.status(504).json({ error: "Request timed out", code: "TIMEOUT" });
   }
   next(err);
 });
 
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-  logger.error("Request error", { error: err.message });
+  logger.error({ error: err.message, stack: err.stack }, "Unhandled error");
 
-  const parseError = err as Error & {
-    type?: string;
-    status?: number;
-    body?: unknown;
-  };
-  if (
-    parseError.type === "entity.parse.failed" ||
-    (err instanceof SyntaxError && typeof parseError.body !== "undefined") ||
-    parseError.status === 400
-  ) {
-    return res.status(400).json({ error: "Invalid JSON request body" });
+  const e = err as any;
+  if (e.type === "entity.parse.failed" || (err instanceof SyntaxError && e.body !== undefined)) {
+    return res.status(400).json({ error: "Invalid JSON body", code: "INVALID_JSON" });
   }
-
-  return res
-    .status(500)
-    .json({ error: err.message || "Internal server error" });
+  if (e.status === 404) {
+    return res.status(404).json({ error: "Resource not found", code: "NOT_FOUND" });
+  }
+  if (e.code === "VALIDATION_ERROR" && e.details) {
+    return res.status(400).json({ error: "Validation failed", code: "VALIDATION_ERROR", details: e.details });
+  }
+  res.status(500).json({ error: err.message || "Internal server error", code: "INTERNAL_ERROR" });
 });
 
 app.listen(PORT, () => {

--- a/backend/src/lib/validation.ts
+++ b/backend/src/lib/validation.ts
@@ -120,6 +120,7 @@ export function validateRequest(schemas: RequestSchemaSet): RequestHandler {
     if (Object.keys(details).length > 0) {
       return res.status(400).json({
         error: "Validation failed",
+        code: "VALIDATION_ERROR",
         details,
       });
     }

--- a/backend/src/middleware/cache.ts
+++ b/backend/src/middleware/cache.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from "express";
+
+const store = new Map<string, { data: unknown; expiresAt: number }>();
+
+export function cacheFor(ttlMs: number) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const key = req.originalUrl;
+    const cached = store.get(key);
+    if (cached && Date.now() < cached.expiresAt) {
+      return res.json(cached.data);
+    }
+    const original = res.json.bind(res);
+    res.json = (data: unknown) => {
+      if (store.size > 500) store.clear(); // bound memory
+      store.set(key, { data, expiresAt: Date.now() + ttlMs });
+      return original(data);
+    };
+    next();
+  };
+}
+
+export function invalidateCache(prefix: string) {
+  for (const key of store.keys()) {
+    if (key.startsWith(prefix)) store.delete(key);
+  }
+}

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -8,6 +8,7 @@ import {
 import { asyncHandler } from "../lib/asyncHandler.js";
 import { validateRequest, RegisterMeterSchema } from "../lib/validation.js";
 import { requireAdminKey } from "../middleware/adminAuth.js";
+import { cacheFor, invalidateCache } from "../middleware/cache.js";
 
 const balanceCache = new Map<string, { data: any; ts: number }>();
 const BALANCE_CACHE_TTL_MS = 5_000; // 5-second cache to reduce RPC load
@@ -77,6 +78,7 @@ export function createMeterRouter(stellar: StellarService) {
   /** GET /api/meters/:id — get meter status */
   meterRouter.get(
     "/:id",
+    cacheFor(5_000),
     asyncHandler(async (req, res) => {
       const result = await stellar.query("get_meter", [
         StellarSdk.nativeToScVal(req.params.id, { type: "symbol" }),
@@ -88,6 +90,7 @@ export function createMeterRouter(stellar: StellarService) {
   /** GET /api/meters/:id/access — check if meter is active */
   meterRouter.get(
     "/:id/access",
+    cacheFor(5_000),
     asyncHandler(async (req, res) => {
       const result = await stellar.query("check_access", [
         StellarSdk.nativeToScVal(req.params.id, { type: "symbol" }),
@@ -107,7 +110,7 @@ export function createMeterRouter(stellar: StellarService) {
           StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
         ]);
       } catch {
-        return res.status(404).json({ error: "Meter not found" });
+        return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
       }
       const hash = await stellar.invoke("set_active", [
         StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
@@ -128,7 +131,7 @@ export function createMeterRouter(stellar: StellarService) {
           StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
         ]);
       } catch {
-        return res.status(404).json({ error: "Meter not found" });
+        return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
       }
       const hash = await stellar.invoke("set_active", [
         StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
@@ -164,7 +167,7 @@ export function createMeterRouter(stellar: StellarService) {
         balanceCache.set(meterId, { data: payload, ts: Date.now() });
         res.json(payload);
       } catch (err: any) {
-        res.status(404).json({ error: "Meter not found" });
+        res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
       }
     }),
   );
@@ -181,7 +184,7 @@ export function createMeterRouter(stellar: StellarService) {
       const history = getUsageHistory(req.params.id, page, pageSize);
       res.json(history);
     } catch (err: any) {
-      res.status(500).json({ error: err.message });
+      res.status(500).json({ error: err.message, code: "INTERNAL_ERROR" });
     }
   });
 
@@ -217,22 +220,22 @@ export function createMeterRouter(stellar: StellarService) {
     const { units, cost } = req.body as { units: unknown; cost: unknown };
 
     if (units == null || cost == null) {
-      return res.status(400).json({ error: "units and cost are required" });
+      return res.status(400).json({ error: "units and cost are required", code: "VALIDATION_ERROR" });
     }
 
     const unitsNum = Number(units);
     const costNum = Number(cost);
 
     if (!Number.isFinite(unitsNum) || !Number.isFinite(costNum)) {
-      return res.status(400).json({ error: "units and cost must be valid numbers" });
+      return res.status(400).json({ error: "units and cost must be valid numbers", code: "VALIDATION_ERROR" });
     }
 
     if (!Number.isInteger(unitsNum) || !Number.isInteger(costNum)) {
-      return res.status(400).json({ error: "units and cost must be integers" });
+      return res.status(400).json({ error: "units and cost must be integers", code: "VALIDATION_ERROR" });
     }
 
     if (unitsNum <= 0 || costNum <= 0) {
-      return res.status(400).json({ error: "units and cost must be positive" });
+      return res.status(400).json({ error: "units and cost must be positive", code: "VALIDATION_ERROR" });
     }
 
     try {
@@ -243,13 +246,15 @@ export function createMeterRouter(stellar: StellarService) {
         sourceTopic: null,
       });
 
+      invalidateCache(`/api/meters/${req.params.id}`);
+
       res.json({
         event,
         hash: event.on_chain_tx_hash,
         queued: !event.on_chain_tx_hash,
       });
     } catch (err: any) {
-      res.status(500).json({ error: err.message });
+      res.status(500).json({ error: err.message, code: "INTERNAL_ERROR" });
     }
   });
 


### PR DESCRIPTION
## Summary

Resolves both #339 and #340 in a single PR.

### Issue #340 — TTL Cache Middleware

- Created `backend/src/middleware/cache.ts` with `cacheFor(ttlMs)` middleware
- In-memory store bounded to 500 entries to prevent memory leaks
- Applied `cacheFor(5_000)` to `GET /api/meters/:id` and `GET /api/meters/:id/access`
- Cache invalidated on `POST /api/meters/:id/usage`

### Issue #339 — Structured Error Responses

- Added 404 catch-all in `index.ts`: `{ error: "Route not found", code: "NOT_FOUND" }`
- Standardised global error handler to `{ error, code }` shape with codes: `NOT_FOUND`, `INVALID_JSON`, `TIMEOUT`, `INTERNAL_ERROR`
- Updated `validateRequest` in `validation.ts` to emit `code: "VALIDATION_ERROR"`
- Updated all inline error responses in `meters.ts` to include a `code` field
- No HTML error responses from Express default handler

Closes #339
Closes #340