### PR TITLE
fix(backend): fix syntax errors in payments route and restore registry backend functionality

### DIFF
--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -42,6 +42,7 @@ paymentsRouter.get(
       Math.max(1, parseInt((req.query.limit as string) ?? "10", 10)),
     );
     const sort = req.query.sort === "asc" ? "asc" : "desc";
+    const days = Math.min(90, Math.max(1, parseInt((req.query.days as string) ?? "30", 10)));
 
     try {
       StellarSdk.StrKey.decodeEd25519PublicKey(address);
@@ -50,7 +51,7 @@ paymentsRouter.get(
     }
 
     try {
-      const records = await fetchPaymentEvents(address, sort);
+      const records = await fetchPaymentEvents(address, sort, days);
       const total = records.length;
       const start = (page - 1) * limit;
       const paginated = records.slice(start, start + limit);
@@ -60,6 +61,10 @@ paymentsRouter.get(
         pagination: { page, limit, total, pages: Math.ceil(total / limit) },
       });
     } catch (err: any) {
+      console.error("payments route error:", err);
+      if (err?.code === 'RPC_ERROR' || err?.isRpcError) {
+        return res.status(502).json({ error: err.message ?? "RPC request failed", code: "RPC_ERROR" });
+      }
       return res.status(500).json({ error: err.message ?? "Failed to fetch payment history" });
     }
   }),
@@ -70,43 +75,45 @@ paymentsRouter.get(
 async function fetchPaymentEvents(
   address: string,
   sort: "asc" | "desc",
+  days = 30,
 ): Promise<PaymentRecord[]> {
-  // Query Soroban RPC for contract events
-  const EVT_NS = StellarSdk.xdr.ScVal.scvSymbol("solargrid").toXDR("base64");
-  const ACTION = StellarSdk.xdr.ScVal.scvSymbol("payment").toXDR("base64");
+  // Query Soroban RPC for contract events within the requested day window
+  try {
+    const EVT_NS = StellarSdk.xdr.ScVal.scvSymbol("solargrid").toXDR("base64");
+    const ACTION = StellarSdk.xdr.ScVal.scvSymbol("payment").toXDR("base64");
 
-  const response = await (server as any).getEvents({
-    startLedger: 1,
-    filters: [
-      {
-        type: "contract",
-        contractIds: [CONTRACT_ID],
-        topics: [
-          [EVT_NS, ACTION],
-        ],
-      },
-    ],
-    limit: 1000,
-  });
+    const response = await (server as any).getEvents({
+      startLedger: 1,
+      filters: [
+        {
+          type: "contract",
+          contractIds: [CONTRACT_ID],
+          topics: [
+            [EVT_NS, ACTION],
+          ],
+        },
+      ],
+      limit: 1000,
+    });
 
-  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
-  const events: PaymentRecord[] = [];
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+    const events: PaymentRecord[] = [];
 
-  for (const event of response?.events ?? []) {
-    try {
-      const record = parsePaymentEvent(event, address);
-      if (record && new Date(record.date).getTime() >= cutoff) events.push(record);
-    } catch {
-      // skip malformed events
+    for (const event of response?.events ?? []) {
+      try {
+        const record = parsePaymentEvent(event, address);
+        if (record && new Date(record.date).getTime() >= cutoff) events.push(record);
+      } catch {
+        // skip malformed events
+      }
     }
-  }
 
-  events.sort((a, b) => {
-    const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
-    return sort === "asc" ? diff : -diff;
-  });
+    events.sort((a, b) => {
+      const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
+      return sort === "asc" ? diff : -diff;
+    });
 
-  return events;
+    return events;
   } catch (err: any) {
     const rpcErr: any = new Error(err.message ?? "RPC request failed");
     rpcErr.isRpcError = true;


### PR DESCRIPTION
Fix the syntax errors in ackend/src/routes/payments.ts by restoring the missing 	ry block and the days parameter. This allows the backend to build cleanly, restoring the registry functionalities and route endpoints for meters.

closes #181