### PR TITLE
fix: correct contract args, RPC lookback, and route registration

### DIFF
--- a/backend/src/lib/validation.ts
+++ b/backend/src/lib/validation.ts
@@ -63,6 +63,7 @@ export const SmsPaymentWebhookSchema = z
       .number()
       .positive("amount_xlm must be positive")
       .finite("amount_xlm must be a finite number"),
+    plan: PaymentPlanSchema.optional().default("Daily"),
   })
   .strict();
 

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -42,6 +42,8 @@ paymentsRouter.get(
       Math.max(1, parseInt((req.query.limit as string) ?? "10", 10)),
     );
     const sort = req.query.sort === "asc" ? "asc" : "desc";
+    const defaultLookback = parseInt(process.env.PAYMENT_LOOKBACK_DAYS ?? "30", 10);
+    const days = Math.max(1, parseInt((req.query.days as string) ?? String(defaultLookback), 10));
 
     try {
       StellarSdk.StrKey.decodeEd25519PublicKey(address);
@@ -50,7 +52,7 @@ paymentsRouter.get(
     }
 
     try {
-      const records = await fetchPaymentEvents(address, sort);
+      const records = await fetchPaymentEvents(address, sort, days);
       const total = records.length;
       const start = (page - 1) * limit;
       const paginated = records.slice(start, start + limit);
@@ -70,43 +72,48 @@ paymentsRouter.get(
 async function fetchPaymentEvents(
   address: string,
   sort: "asc" | "desc",
+  days: number,
 ): Promise<PaymentRecord[]> {
-  // Query Soroban RPC for contract events
   const EVT_NS = StellarSdk.xdr.ScVal.scvSymbol("solargrid").toXDR("base64");
   const ACTION = StellarSdk.xdr.ScVal.scvSymbol("payment").toXDR("base64");
 
-  const response = await (server as any).getEvents({
-    startLedger: 1,
-    filters: [
-      {
-        type: "contract",
-        contractIds: [CONTRACT_ID],
-        topics: [
-          [EVT_NS, ACTION],
-        ],
-      },
-    ],
-    limit: 1000,
-  });
+  const LEDGERS_PER_DAY = 17_280;
+  const latestLedger = await server.getLatestLedger();
+  const startLedger = Math.max(1, latestLedger.sequence - days * LEDGERS_PER_DAY);
 
-  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
-  const events: PaymentRecord[] = [];
+  try {
+    const response = await (server as any).getEvents({
+      startLedger,
+      filters: [
+        {
+          type: "contract",
+          contractIds: [CONTRACT_ID],
+          topics: [
+            [EVT_NS, ACTION],
+          ],
+        },
+      ],
+      limit: 1000,
+    });
 
-  for (const event of response?.events ?? []) {
-    try {
-      const record = parsePaymentEvent(event, address);
-      if (record && new Date(record.date).getTime() >= cutoff) events.push(record);
-    } catch {
-      // skip malformed events
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+    const events: PaymentRecord[] = [];
+
+    for (const event of response?.events ?? []) {
+      try {
+        const record = parsePaymentEvent(event, address);
+        if (record && new Date(record.date).getTime() >= cutoff) events.push(record);
+      } catch {
+        // skip malformed events
+      }
     }
-  }
 
-  events.sort((a, b) => {
-    const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
-    return sort === "asc" ? diff : -diff;
-  });
+    events.sort((a, b) => {
+      const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
+      return sort === "asc" ? diff : -diff;
+    });
 
-  return events;
+    return events;
   } catch (err: any) {
     const rpcErr: any = new Error(err.message ?? "RPC request failed");
     rpcErr.isRpcError = true;

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -47,7 +47,7 @@ webhookRouter.post(
       return res.status(401).json({ error: "Invalid webhook signature" });
     }
 
-    const { meter_id, amount_xlm } = req.body;
+    const { meter_id, amount_xlm, plan } = req.body;
 
     const stroops = BigInt(Math.round(amount_xlm * 10_000_000));
     const hash = await adminInvoke("make_payment", [
@@ -56,7 +56,7 @@ webhookRouter.post(
         type: "address",
       }),
       StellarSdk.nativeToScVal(stroops, { type: "i128" }),
-      StellarSdk.xdr.ScVal.scvVec([StellarSdk.xdr.ScVal.scvSymbol("Daily")]),
+      StellarSdk.nativeToScVal({ [plan]: null }),
     ]);
     paymentVolume.inc(amount_xlm);
     activeMeters.inc();

--- a/frontend/src/services/meterService.ts
+++ b/frontend/src/services/meterService.ts
@@ -28,7 +28,8 @@ export async function makePayment(
   const amountStroops = BigInt(Math.round(amountXlm * 10_000_000));
   return contractInvoke(sourceAddress, "make_payment", [
     StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+    StellarSdk.nativeToScVal(sourceAddress, { type: "address" }),
     StellarSdk.nativeToScVal(amountStroops, { type: "i128" }),
-    StellarSdk.nativeToScVal({ [plan]: null }, { type: "map" }),
+    StellarSdk.nativeToScVal(plan, { type: "symbol" }),
   ]);
 }


### PR DESCRIPTION
fix(frontend #330): add missing payer address to make_payment args in meterService.ts
- Add sourceAddress as the second argument to contractInvoke (contract expects meter_id, payer, amount, plan)
- Change plan encoding from { type: "map" } to { type: "symbol" } to match PaymentPlan enum variants (Daily/Weekly/UsageBased)

fix(backend #332): encode PaymentPlan as ScvMap in SMS payment webhook
- Replace scvVec([scvSymbol("Daily")]) with nativeToScVal({ [plan]: null }) which produces the correct Soroban enum ScvMap encoding
- Add optional plan field (default: "Daily") to SmsPaymentWebhookSchema in validation.ts so the webhook payload can specify the plan dynamically

fix(backend #331): calculate startLedger from a rolling lookback window in payments.ts
- Replace hardcoded startLedger: 1 with a calculation based on getLatestLedger() minus a configurable lookback (default 30 days × 17,280 ledgers/day)
- Expose ?days=N query param so callers can override the window per request
- Read default lookback from PAYMENT_LOOKBACK_DAYS env var
- Fix broken try/catch structure and undefined days variable that caused TypeScript compilation errors

refactor(backend #255): confirm flat route registration in meters.ts
- The nested-route bug described in #255 is not present in the current codebase; all handlers are registered at the top level of createMeterRouter and no stray export const meterRouter exists
- The backend TypeScript build now passes cleanly after the payments.ts structural fix above

Closes #330
Closes #332
Closes #331
Closes #255