### PR TITLE
feat(api): 404 middleware, /api/health, body size cap, OpenAPI spec 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ The `SolarGrid` contract manages:
 
 ## Backend API
 
+The full machine-readable API specification is available at [`backend/openapi.yaml`](backend/openapi.yaml) (OpenAPI 3.1). You can preview it with:
+
+```bash
+npx @redocly/cli preview-docs backend/openapi.yaml
+```
+
 ### Meter Balance
 
 **`GET /api/meters/:id/balance`**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,10 @@ TX_POLL_INTERVAL_MS=2000
 # Accepts values like '15s', '30s', '1m'. Default: 15s
 REQUEST_TIMEOUT=15s
 
+# Maximum allowed JSON/URL-encoded body size. Default: 100kb
+# Accepts values like '50kb', '1mb'. Requests exceeding this return 413.
+REQUEST_BODY_LIMIT=100kb
+
 # Max reconnect attempts for IoT bridge MQTT connection before alerting and stopping (default: 10)
 MQTT_MAX_RECONNECT_ATTEMPTS=10
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,937 @@
+openapi: 3.1.0
+info:
+  title: Stellar Solar Grid API
+  version: 0.1.0
+  description: REST API for the Stellar SolarGrid PAYG solar energy platform.
+
+servers:
+  - url: http://localhost:3001
+    description: Local development
+
+components:
+  securitySchemes:
+    AdminKey:
+      type: apiKey
+      in: header
+      name: X-Admin-Key
+
+  schemas:
+    Error:
+      type: object
+      required: [error, code]
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+        hint:
+          type: string
+
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            details:
+              type: array
+              items:
+                type: object
+
+    HealthResponse:
+      type: object
+      required: [status, version, uptimeSec, dependencies]
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded]
+        version:
+          type: string
+        uptimeSec:
+          type: integer
+        dependencies:
+          type: object
+          required: [stellarRpc, mqtt]
+          properties:
+            stellarRpc:
+              type: string
+              enum: [ok, unreachable]
+            mqtt:
+              type: string
+              enum: [ok, unreachable]
+
+    Pagination:
+      type: object
+      required: [page, pageSize, total, pages]
+      properties:
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+        pages:
+          type: integer
+
+    Meter:
+      type: object
+      properties:
+        owner:
+          type: string
+        active:
+          type: boolean
+        units_used:
+          type: integer
+        plan:
+          type: string
+        last_payment:
+          type: integer
+        expires_at:
+          type: integer
+        daily_limit:
+          type: integer
+
+    PaymentRecord:
+      type: object
+      required: [txHash, date, meterId, amountXlm, plan]
+      properties:
+        txHash:
+          type: string
+        date:
+          type: string
+          format: date-time
+        meterId:
+          type: string
+        amountXlm:
+          type: number
+        plan:
+          type: string
+
+    CollaboratorShare:
+      type: object
+      required: [address, basisPoints]
+      properties:
+        address:
+          type: string
+        basisPoints:
+          type: integer
+
+    UsageEvent:
+      type: object
+      properties:
+        id:
+          type: integer
+        meter_id:
+          type: string
+        units:
+          type: integer
+        cost:
+          type: integer
+        on_chain_tx_hash:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+  responses:
+    BadRequest:
+      description: Invalid request parameters or body
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Missing or invalid admin key
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    PayloadTooLarge:
+      description: Request body exceeds the 100 kb limit
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+paths:
+  # ── Health ──────────────────────────────────────────────────────────────────
+  /api/health:
+    get:
+      operationId: getHealth
+      summary: Health check
+      description: Returns service version, uptime, and dependency status. Used by load balancers and Docker healthchecks.
+      tags: [Health]
+      responses:
+        '200':
+          description: All dependencies healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '503':
+          description: One or more dependencies unreachable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  # ── Meters ──────────────────────────────────────────────────────────────────
+  /api/meters:
+    get:
+      operationId: listMeters
+      summary: List all meters (paginated)
+      tags: [Meters]
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 25
+            maximum: 100
+      responses:
+        '200':
+          description: Paginated list of meters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meters:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Meter'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      operationId: registerMeter
+      summary: Register a new meter (admin only)
+      tags: [Meters]
+      security:
+        - AdminKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [meter_id, owner]
+              properties:
+                meter_id:
+                  type: string
+                owner:
+                  type: string
+                  description: Stellar Ed25519 public key
+      responses:
+        '200':
+          description: Meter registered; returns transaction hash
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+
+  /api/meters/export:
+    get:
+      operationId: exportMeters
+      summary: Export all meter data as CSV or JSON
+      tags: [Meters]
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [csv, json]
+            default: csv
+      responses:
+        '200':
+          description: Meter data file
+          content:
+            text/csv:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Meter'
+
+  /api/meters/owner/{address}:
+    get:
+      operationId: getMetersByOwner
+      summary: List all meters for a given owner address
+      tags: [Meters]
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+          description: Stellar Ed25519 public key
+      responses:
+        '200':
+          description: Meters owned by address
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meters:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Meter'
+                  owner:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/meters/{id}:
+    get:
+      operationId: getMeter
+      summary: Get meter status
+      tags: [Meters]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Meter data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meter:
+                    $ref: '#/components/schemas/Meter'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/meters/{id}/access:
+    get:
+      operationId: checkMeterAccess
+      summary: Check whether a meter is currently active
+      tags: [Meters]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Active flag
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  active:
+                    type: boolean
+
+  /api/meters/{id}/balance:
+    get:
+      operationId: getMeterBalance
+      summary: Live balance for a single meter (cached 5 s)
+      tags: [Meters]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Meter balance
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [meter_id, balance, units_used, active]
+                properties:
+                  meter_id:
+                    type: string
+                  balance:
+                    type: integer
+                  units_used:
+                    type: integer
+                  active:
+                    type: boolean
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/meters/{id}/history:
+    get:
+      operationId: getMeterHistory
+      summary: Paginated local usage history for a meter
+      tags: [Meters]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 25
+            maximum: 100
+      responses:
+        '200':
+          description: Usage history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsageEvent'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+
+  /api/meters/{id}/usage:
+    post:
+      operationId: reportUsage
+      summary: IoT oracle reports energy usage for a meter (admin only)
+      tags: [Meters]
+      security:
+        - AdminKey: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [units, cost]
+              properties:
+                units:
+                  type: integer
+                  minimum: 1
+                cost:
+                  type: integer
+                  minimum: 1
+      responses:
+        '200':
+          description: Usage event persisted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event:
+                    $ref: '#/components/schemas/UsageEvent'
+                  hash:
+                    type: string
+                    nullable: true
+                  queued:
+                    type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+
+  /api/meters/{id}/activate:
+    post:
+      operationId: activateMeter
+      summary: Admin manually activates a meter
+      tags: [Meters]
+      security:
+        - AdminKey: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Meter activated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+                  meter_id:
+                    type: string
+                  active:
+                    type: boolean
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/meters/{id}/deactivate:
+    post:
+      operationId: deactivateMeter
+      summary: Admin manually deactivates a meter
+      tags: [Meters]
+      security:
+        - AdminKey: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Meter deactivated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+                  meter_id:
+                    type: string
+                  active:
+                    type: boolean
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/meters/{id}/set-daily-limit:
+    post:
+      operationId: setDailyLimit
+      summary: Admin sets daily spending limit for a meter
+      tags: [Meters]
+      security:
+        - AdminKey: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [limit]
+              properties:
+                limit:
+                  type: integer
+                  minimum: 0
+                  description: Daily limit in stroops
+      responses:
+        '200':
+          description: Daily limit set
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+                  meter_id:
+                    type: string
+                  daily_limit:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ── Payments ────────────────────────────────────────────────────────────────
+  /api/payments/{address}:
+    get:
+      operationId: getPayments
+      summary: Payment history for a Stellar address
+      tags: [Payments]
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+          description: Stellar Ed25519 public key
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 10
+            maximum: 50
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - in: query
+          name: days
+          schema:
+            type: integer
+            default: 30
+            maximum: 90
+      responses:
+        '200':
+          description: Payment history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PaymentRecord'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # ── Webhooks ─────────────────────────────────────────────────────────────────
+  /api/webhooks/sms-payment:
+    post:
+      operationId: smsPaymentWebhook
+      summary: Telecom partner webhook — triggers on-chain payment
+      description: Requires a valid HMAC-SHA256 signature in the X-Webhook-Signature header.
+      tags: [Webhooks]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [meter_id, amount_xlm]
+              properties:
+                meter_id:
+                  type: string
+                amount_xlm:
+                  type: number
+                plan:
+                  type: string
+                  default: daily
+      responses:
+        '200':
+          description: Payment submitted on-chain
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+
+  /api/webhooks/low-balance:
+    post:
+      operationId: registerLowBalanceWebhook
+      summary: Register a webhook URL for low-balance notifications
+      tags: [Webhooks]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [webhook_url]
+              properties:
+                webhook_url:
+                  type: string
+                  format: uri
+      responses:
+        '200':
+          description: Webhook registered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  webhook_url:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  # ── Allowlist ────────────────────────────────────────────────────────────────
+  /api/allowlist:
+    get:
+      operationId: getAllowlist
+      summary: Get all allowlisted addresses
+      tags: [Allowlist]
+      responses:
+        '200':
+          description: Allowlisted addresses
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  addresses:
+                    type: array
+                    items:
+                      type: string
+
+    post:
+      operationId: addToAllowlist
+      summary: Add an address to the allowlist (admin only)
+      tags: [Allowlist]
+      security:
+        - AdminKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [address]
+              properties:
+                address:
+                  type: string
+                  minLength: 56
+                  maxLength: 56
+      responses:
+        '200':
+          description: Address added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/allowlist/{address}:
+    delete:
+      operationId: removeFromAllowlist
+      summary: Remove an address from the allowlist (admin only)
+      tags: [Allowlist]
+      security:
+        - AdminKey: []
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Address removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ── Collaborators ────────────────────────────────────────────────────────────
+  /api/collaborators:
+    get:
+      operationId: getCollaborators
+      summary: List all collaborators and their revenue shares
+      tags: [Collaborators]
+      responses:
+        '200':
+          description: Collaborator list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  collaborators:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CollaboratorShare'
+
+    post:
+      operationId: addCollaborator
+      summary: Add a collaborator (admin only)
+      tags: [Collaborators]
+      security:
+        - AdminKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [address, basis_points]
+              properties:
+                address:
+                  type: string
+                basis_points:
+                  type: integer
+                  minimum: 0
+                  maximum: 10000
+      responses:
+        '200':
+          description: Collaborator added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/collaborators/{address}:
+    delete:
+      operationId: removeCollaborator
+      summary: Remove a collaborator (admin only)
+      tags: [Collaborators]
+      security:
+        - AdminKey: []
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Collaborator removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # ── Stats ────────────────────────────────────────────────────────────────────
+  /api/stats:
+    get:
+      operationId: getStats
+      summary: Contract-derived meter statistics (cached 30 s)
+      tags: [Stats]
+      responses:
+        '200':
+          description: Aggregate stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totalMeters:
+                    type: integer
+                  activeMeters:
+                    type: integer
+                  totalUnits:
+                    type: integer
+                  totalRevenue:
+                    type: integer
+
+  /api/stats/summary:
+    get:
+      operationId: getStatsSummary
+      summary: Prometheus counter/gauge snapshot for the admin dashboard (cached 15 s)
+      tags: [Stats]
+      responses:
+        '200':
+          description: Metrics snapshot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  mqttMessages:
+                    type: number
+                  contractCalls:
+                    type: number
+                  activeMeters:
+                    type: number
+                  paymentVolumeXlm:
+                    type: number
+
+  # ── Metrics ──────────────────────────────────────────────────────────────────
+  /api/metrics/summary:
+    get:
+      operationId: getMetricsSummary
+      summary: JSON snapshot of core prom-client counters/gauges (cached 15 s)
+      tags: [Metrics]
+      responses:
+        '200':
+          description: Metrics snapshot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  mqttMessages:
+                    type: number
+                  contractCalls:
+                    type: number
+                  activeMeters:
+                    type: number
+                  paymentVolumeXlm:
+                    type: number

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,7 @@
-﻿import "dotenv/config";
-import express from "express";
+import "dotenv/config";
+import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
 import timeout from "connect-timeout";
-import { NextFunction, Request, Response } from "express";
 import mqtt from "mqtt";
 import { stellarService, server } from "./lib/stellar.js";
 import { createMeterRouter } from "./routes/meters.js";
@@ -14,22 +13,18 @@ import { statsRouter } from "./routes/stats.js";
 import { startIoTBridge } from "./iot/bridge.js";
 import { requestLogger } from "./middleware/index.js";
 import { logger } from "./lib/logger.js";
-import requestLogger from "./middleware/requestLogger.js";
 import { register } from "./lib/metrics.js";
 import {
   initUsageEventStore,
   startUsageEventRetryWorker,
 } from "./lib/usageEvents.js";
 import { metricsRouter } from "./routes/metrics.js";
+import { createRequire } from "module";
+
+const _require = createRequire(import.meta.url);
+const { version } = _require("../../package.json") as { version: string };
 
 const REQUIRED_ENV = ["CONTRACT_ID", "ADMIN_SECRET_KEY", "STELLAR_RPC_URL", "MQTT_BROKER"];
-const PORT = process.env.PORT ?? 3001;
-
-app.use(express.json());
-app.use(requestLogger);
-app.use((_, res, next) => {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 const missing = REQUIRED_ENV.filter((k) => !process.env[k]);
 if (missing.length > 0) {
   logger.fatal(
@@ -39,7 +34,12 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
+const PORT = process.env.PORT ?? 3001;
+// #423: configurable body size limit
+const BODY_LIMIT = process.env.REQUEST_BODY_LIMIT ?? "100kb";
+
 const app = express();
+const startTime = Date.now();
 
 app.use(
   cors({
@@ -50,22 +50,24 @@ app.use(
   })
 );
 
-// Capture raw body for webhook signature verification before JSON parsing
+// Capture raw body for webhook signature verification before JSON parsing.
+// #423: apply body size limit
 app.use(
   express.json({
+    limit: BODY_LIMIT,
     verify: (req: any, _res, buf) => {
       req.rawBody = buf;
     },
   }),
 );
+app.use(express.urlencoded({ extended: true, limit: BODY_LIMIT }));
 
 app.use(requestLogger);
 
 // Request timeout — configurable via REQUEST_TIMEOUT env var (default 15s)
-const requestTimeout = process.env.REQUEST_TIMEOUT ?? '15s';
+const requestTimeout = process.env.REQUEST_TIMEOUT ?? "15s";
 app.use(timeout(requestTimeout));
 
-// Halt middleware chain if request has already timed out
 app.use((req: any, _res: any, next: any) => {
   if (!req.timedout) next();
 });
@@ -75,6 +77,8 @@ app.use((req, _res, next) => {
   next();
 });
 
+// ── Routes ────────────────────────────────────────────────────────────────────
+
 app.use("/api/meters", createMeterRouter(stellarService));
 app.use("/api/payments", paymentsRouter);
 app.use("/api/webhooks", webhookRouter);
@@ -83,47 +87,43 @@ app.use("/api/collaborators", collaboratorRouter);
 app.use("/api/stats", statsRouter);
 app.use("/api/metrics", metricsRouter);
 
-app.get('/health', async (_req, res) => {
-  const checks: Record<string, string> = {};
+// #420: GET /api/health — version, uptime, dependency status
+app.get("/api/health", async (_req, res) => {
+  const uptimeSec = Math.floor((Date.now() - startTime) / 1000);
 
   // Check Stellar RPC
+  let rpcOk = false;
   try {
     await server.getLatestLedger();
-    checks.stellar = 'ok';
-  } catch (err) {
-    logger.error('Stellar health check failed', { err });
-    checks.stellar = 'error';
+    rpcOk = true;
+  } catch {
+    logger.warn("Stellar RPC health check failed");
   }
 
-  // Check MQTT by attempting a short-lived connection
-  const broker = process.env.MQTT_BROKER ?? 'mqtt://localhost:1883';
+  // Check MQTT
+  const broker = process.env.MQTT_BROKER ?? "mqtt://localhost:1883";
+  let mqttOk = false;
   try {
     const client = mqtt.connect(broker, { reconnectPeriod: 0, connectTimeout: 3000 });
-    const ok = await new Promise<boolean>((resolve) => {
-      const onConnect = () => {
-        client.end(true);
-        resolve(true);
-      };
-      const onError = () => {
-        client.end(true);
-        resolve(false);
-      };
-      const timer = setTimeout(() => {
-        client.end(true);
-        resolve(false);
-      }, 3000);
-
-      client.once('connect', () => { clearTimeout(timer); onConnect(); });
-      client.once('error', () => { clearTimeout(timer); onError(); });
+    mqttOk = await new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => { client.end(true); resolve(false); }, 3000);
+      client.once("connect", () => { clearTimeout(timer); client.end(true); resolve(true); });
+      client.once("error", () => { clearTimeout(timer); client.end(true); resolve(false); });
     });
-    checks.mqtt = ok ? 'ok' : 'error';
-  } catch (err) {
-    logger.error('MQTT health check failed', { err });
-    checks.mqtt = 'error';
+  } catch {
+    logger.warn("MQTT health check failed");
   }
 
-  const healthy = Object.values(checks).every((v) => v === 'ok');
-  res.status(healthy ? 200 : 503).json({ status: healthy ? 'ok' : 'degraded', checks });
+  const healthy = rpcOk && mqttOk;
+  res.status(healthy ? 200 : 503).json({
+    status: healthy ? "ok" : "degraded",
+    version,
+    uptimeSec,
+    dependencies: {
+      stellarRpc: rpcOk ? "ok" : "unreachable",
+      mqtt: mqttOk ? "ok" : "unreachable",
+    },
+  });
 });
 
 app.get("/metrics", async (_req, res) => {
@@ -131,50 +131,47 @@ app.get("/metrics", async (_req, res) => {
   res.end(await register.metrics());
 });
 
-// 404 catch-all — must come after all routes
-app.use((_req: Request, res: Response) =>
-  res.status(404).json({ error: "Route not found", code: "NOT_FOUND" })
-);
+// #418: 404 catch-all — must come after all routes
+app.use((_req: Request, res: Response) => {
+  res.status(404).json({
+    error: "Route not found",
+    code: "NOT_FOUND",
+    hint: "Check /api/docs for available endpoints",
+  });
+});
 
-// Timeout error handler — must come before the generic error handler
+// Timeout error handler
 app.use((err: any, req: any, res: any, next: any) => {
   if (req.timedout) {
-    logger.error('Request timed out', {
-      method: req.method,
-      path: req.path,
-      timeout: requestTimeout,
-    });
+    logger.error("Request timed out", { method: req.method, path: req.path });
     return res.status(504).json({ error: "Request timed out", code: "TIMEOUT" });
   }
   next(err);
 });
 
-app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+// #423: 413 payload too large handler + global error handler (#418)
+app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
   logger.error({ error: err.message, stack: err.stack }, "Unhandled error");
 
-  const e = err as any;
-  if (e.type === "entity.parse.failed" || (err instanceof SyntaxError && e.body !== undefined)) {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", code: "PAYLOAD_TOO_LARGE" });
+  }
+  if (err.type === "entity.parse.failed" || (err instanceof SyntaxError && err.body !== undefined)) {
     return res.status(400).json({ error: "Invalid JSON body", code: "INVALID_JSON" });
   }
-  if (e.status === 404) {
+  if ((err as any).status === 404) {
     return res.status(404).json({ error: "Resource not found", code: "NOT_FOUND" });
   }
-  if (e.code === "VALIDATION_ERROR" && e.details) {
-    return res.status(400).json({ error: "Validation failed", code: "VALIDATION_ERROR", details: e.details });
+  if ((err as any).code === "VALIDATION_ERROR" && (err as any).details) {
+    return res.status(400).json({ error: "Validation failed", code: "VALIDATION_ERROR", details: (err as any).details });
   }
   res.status(500).json({ error: err.message || "Internal server error", code: "INTERNAL_ERROR" });
 });
 
 app.listen(PORT, () => {
-  console.log(`SolarGrid backend running on port ${PORT}`);
-  startIoTBridge();
-  logger.info(
-    { port: PORT, network: process.env.STELLAR_NETWORK ?? "testnet" },
-    "SolarGrid backend started"
-  );
+  logger.info({ port: PORT, network: process.env.STELLAR_NETWORK ?? "testnet" }, "SolarGrid backend started");
   initUsageEventStore();
   startUsageEventRetryWorker();
-  logger.info("SolarGrid backend listening", { port: PORT });
   try {
     startIoTBridge();
   } catch (err) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,9 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3001/health]
-      interval: 15s
-      timeout: 5s
+      test: [CMD, wget, -qO-, http://localhost:3001/api/health]
+      interval: 30s
+      timeout: 10s
       retries: 3
       start_period: 10s
 


### PR DESCRIPTION
## Summary

Four hardening improvements to the Express backend, implemented in a single cohesive change to `backend/src/index.ts`.

---

## Changes

closes #418 — Structured JSON 404 + global error handler
- Added catch-all 404 middleware (after all routes) returning `{ error, code, hint }` with `Content-Type: application/json`.
- `hint` references `/api/docs` for discoverability.
- Global error handler covers unhandled sync/async errors.

closes #419 — OpenAPI 3.1 specification
- Created `backend/openapi.yaml` covering every `/api/*` route across `meters`, `payments`, `webhooks`, `allowlist`, `collaborators`, `stats`, and `metrics`.
- Each route documents path/query params, request body schema, and response schemas.
- Shared `400`, `401`, `404`, `413`, `500` error response components.
- Linked from README with `npx @redocly/cli preview-docs` snippet.

closes #420 — `GET /api/health` endpoint
- Returns `{ status, version, uptimeSec, dependencies: { stellarRpc, mqtt } }`.
- `200 ok` when both dependencies reachable; `503 degraded` otherwise.
- Version read from `package.json` at startup via `createRequire`.
- Docker Compose healthcheck updated from `/health` → `/api/health` with `interval: 30s / timeout: 10s / retries: 3`.

closes #423 — Request body size cap
- `express.json` and `express.urlencoded` now use `limit: BODY_LIMIT` (default `100kb`).
- Configurable via `REQUEST_BODY_LIMIT` env var (documented in `.env.example`).
- Global error handler returns `{ error: 'Request body too large', code: 'PAYLOAD_TOO_LARGE' }` on 413 instead of Express's default HTML response.

---

## Files Changed

| File | Change |
|---|---|
| `backend/src/index.ts` | All four features |
| `backend/openapi.yaml` | New — OpenAPI 3.1 spec |
| `backend/.env.example` | `REQUEST_BODY_LIMIT` documented |
| `docker-compose.yml` | Healthcheck URL + timing updated |
| `README.md` | Backend API section links openapi.yaml |

---

## Testing

- Unknown routes (e.g. `GET /api/meterz`) now return `application/json` 404 with `hint` field.
- `GET /api/health` reachable without auth; returns dependency map.
- Sending a body `>` 100 kb returns `413 PAYLOAD_TOO_LARGE` JSON (not HTML).
- `npx @redocly/cli lint backend/openapi.yaml` passes.