### PR TITLE
Fix: resolve backend issues 465-468

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.6",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.5.0",
         "helmet": "^8.2.0",
         "mqtt": "^5.7.0",
         "pino": "^10.3.1",
@@ -28,6 +29,7 @@
         "@eslint/js": "^10.0.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/connect-timeout": "^0.0.39",
+        "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.14.2",
         "@types/swagger-ui-express": "^4.1.8",
@@ -807,6 +809,7 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2400,6 +2403,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,4 @@
 import "dotenv/config";
-import express from "express";
 import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
 import timeout from "connect-timeout";
@@ -13,20 +12,20 @@ import { paymentsRouter } from "./routes/payments.js";
 import { webhookRouter } from "./routes/webhooks.js";
 import { collaboratorRouter } from "./routes/collaborators.js";
 import { allowlistRouter } from "./routes/allowlist.js";
-import { startIoTBridge } from "./iot/bridge.js";
-import { logger } from "./lib/logger.js";
-import { writeLimiter, readLimiter } from "./middleware/rateLimit.js";
-import { collaboratorRouter } from "./routes/collaborators.js";
 import { statsRouter } from "./routes/stats.js";
+import { metricsRouter } from "./routes/metrics.js";
 import { startIoTBridge } from "./iot/bridge.js";
 import { startLimitWatcher } from "./iot/limitWatcher.js";
 import { logger } from "./lib/logger.js";
 import { register } from "./lib/metrics.js";
+import { writeLimiter, readLimiter } from "./middleware/rateLimit.js";
+import { sanitiseBody } from "./middleware/sanitise.js";
+import requestLoggerMiddleware from "./middleware/requestLogger.js";
+import rateLimit from "express-rate-limit";
 import {
   initUsageEventStore,
   startUsageEventRetryWorker,
 } from "./lib/usageEvents.js";
-import { metricsRouter } from "./routes/metrics.js";
 import { createRequire } from "module";
 
 const _require = createRequire(import.meta.url);
@@ -173,15 +172,11 @@ app.get("/api/health", async (_req, res) => {
   }
 
   // Check MQTT
-  const broker = process.env.MQTT_BROKER ?? "mqtt://localhost:1883";
   let mqttOk = false;
   try {
-    const client = mqtt.connect(broker, { reconnectPeriod: 0, connectTimeout: 3000 });
-    mqttOk = await new Promise<boolean>((resolve) => {
-      const timer = setTimeout(() => { client.end(true); resolve(false); }, 3000);
-      client.once("connect", () => { clearTimeout(timer); client.end(true); resolve(true); });
-      client.once("error", () => { clearTimeout(timer); client.end(true); resolve(false); });
-    });
+    const { getMqttClient } = await import("./iot/bridge.js");
+    const client = getMqttClient();
+    mqttOk = client?.connected ?? false;
   } catch {
     logger.warn("MQTT health check failed");
   }
@@ -228,7 +223,7 @@ app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
   if (err.type === "entity.too.large") {
     return res.status(413).json({ error: "Request body too large", code: "PAYLOAD_TOO_LARGE" });
   }
-  if (err.type === "entity.parse.failed" || (err instanceof SyntaxError && err.body !== undefined)) {
+  if (err.type === "entity.parse.failed" || (err instanceof SyntaxError && (err as any).body !== undefined)) {
     return res.status(400).json({ error: "Invalid JSON body", code: "INVALID_JSON" });
   }
   if ((err as any).status === 404) {

--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -27,6 +27,7 @@ const TOPIC = "solargrid/meters/+/usage";
 const MAX_REPLAY_LEDGERS = Number(process.env.MAX_REPLAY_LEDGERS ?? 1000);
 
 let mqttClient: mqtt.MqttClient | null = null;
+export function getMqttClient() { return mqttClient; }
 const FLUSH_INTERVAL_MS = Number(process.env.BATCH_FLUSH_MS ?? 5_000);
 const EVENT_POLL_INTERVAL_MS = Number(
   process.env.EVENT_POLL_INTERVAL_MS ?? 5_000,

--- a/backend/src/lib/asyncHandler.ts
+++ b/backend/src/lib/asyncHandler.ts
@@ -1,16 +1,4 @@
-﻿import { Request, Response, NextFunction } from 'express';
 
-/**
- * Wraps an async Express route handler and forwards any thrown errors
- * to the next() error middleware, avoiding unhandled promise rejections.
- */
-export function asyncHandler(
-  fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>
-) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    Promise.resolve(fn(req, res, next)).catch(next);
-  };
-}
 import { NextFunction, Request, RequestHandler, Response } from "express";
 
 type AsyncRouteHandler = (

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,17 +1,4 @@
-﻿/**
- * Minimal structured logger using console.
- * Swap for winston/pino without changing call sites.
- */
-export const logger = {
-  info(data: Record<string, unknown>) {
-    console.log(JSON.stringify({ level: 'info', ...data, ts: new Date().toISOString() }));
-  },
-  warn(data: Record<string, unknown>) {
-    console.warn(JSON.stringify({ level: 'warn', ...data, ts: new Date().toISOString() }));
-  },
-  error(data: Record<string, unknown>) {
-    console.error(JSON.stringify({ level: 'error', ...data, ts: new Date().toISOString() }));
-  },
+
 import winston from "winston";
 
 const isProduction = process.env.NODE_ENV === "production";

--- a/backend/src/lib/validation.ts
+++ b/backend/src/lib/validation.ts
@@ -1,24 +1,4 @@
-﻿import { Request, Response, NextFunction } from 'express';
-import { ZodSchema, ZodError } from 'zod';
 
-/**
- * Validates req.body against the provided Zod schema.
- * Returns 400 with validation errors if the body is invalid.
- */
-export function validateRequest<T>(schema: ZodSchema<T>) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const result = schema.safeParse(req.body);
-    if (!result.success) {
-      const errors = (result.error as ZodError).errors.map((e) => ({
-        path: e.path.join('.'),
-        message: e.message,
-      }));
-      return res.status(400).json({ error: 'Validation failed', details: errors });
-    }
-    req.body = result.data;
-    next();
-  };
-}
 import type { RequestHandler } from "express";
 import { z, type ZodTypeAny } from "zod";
 

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -1,13 +1,4 @@
-﻿import { Request, Response, NextFunction } from 'express';
 
-export function requireAdminKey(
-  req: Request,
-  res: Response,
-  next: NextFunction
-) {
-  const key = process.env.ADMIN_API_KEY;
-  if (!key) return next();
-  if (req.headers['x-admin-key'] !== key) {
 import { Request, Response, NextFunction } from 'express';
 import { logger } from '../lib/logger.js';
 

--- a/backend/src/middleware/index.ts
+++ b/backend/src/middleware/index.ts
@@ -1,4 +1,3 @@
-﻿export { asyncHandler } from '../lib/asyncHandler.js';
 export { asyncHandler } from '../lib/asyncHandler.js';
 export { validateRequest } from '../lib/validation.js';
 export { requireAdminKey } from './adminAuth.js';

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,18 +1,4 @@
-﻿import { Request, Response, NextFunction } from 'express';
-import { logger } from '../lib/logger.js';
-import { randomUUID } from 'crypto';
 
-export default function requestLogger(
-  req: Request,
-  _res: Response,
-  next: NextFunction
-) {
-  (req as any).reqId = randomUUID();
-  logger.info({
-    reqId: (req as any).reqId,
-    method: req.method,
-    path: req.path,
-  });
 import { Request, Response, NextFunction } from 'express';
 import { logger } from '../lib/logger.js';
 import { randomUUID } from 'crypto';

--- a/backend/src/routes/allowlist.ts
+++ b/backend/src/routes/allowlist.ts
@@ -1,45 +1,5 @@
 import { Router } from 'express';
 import * as StellarSdk from '@stellar/stellar-sdk';
-import { contractQuery, adminInvoke } from '../lib/stellar.js';
-import { asyncHandler } from '../lib/asyncHandler.js';
-
-export const allowlistRouter = Router();
-
-allowlistRouter.get('/', asyncHandler(async (req, res) => {
-  const page = Math.max(1, parseInt((req.query.page as string) ?? '1', 10));
-  const limit = Math.min(200, Math.max(1, parseInt((req.query.limit as string) ?? '50', 10)));
-  const raw = await contractQuery('get_allowlist', []);
-  const all: string[] = (StellarSdk.scValToNative(raw) as string[]) ?? [];
-  const start = (page - 1) * limit;
-  const data = all.slice(start, start + limit);
-  return res.json({ data, total: all.length, page, limit });
-}));
-
-allowlistRouter.post('/', asyncHandler(async (req, res) => {
-  const { address } = req.body as { address?: string };
-  if (!address || typeof address !== 'string') {
-    return res.status(400).json({ error: 'address is required', code: 'VALIDATION_ERROR' });
-  }
-  try {
-    StellarSdk.StrKey.decodeEd25519PublicKey(address);
-  } catch {
-    return res.status(400).json({ error: 'Invalid Stellar address', code: 'VALIDATION_ERROR' });
-  }
-  const hash = await adminInvoke('add_to_allowlist', [
-    StellarSdk.nativeToScVal(address, { type: 'address' }),
-  ]);
-  return res.json({ hash });
-}));
-
-allowlistRouter.delete('/', asyncHandler(async (req, res) => {
-  const { address } = req.body as { address?: string };
-  if (!address || typeof address !== 'string') {
-    return res.status(400).json({ error: 'address is required', code: 'VALIDATION_ERROR' });
-  }
-  const hash = await adminInvoke('remove_from_allowlist', [
-    StellarSdk.nativeToScVal(address, { type: 'address' }),
-  ]);
-  return res.json({ hash });
 import { stellarService } from '../lib/stellar.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
 import { requireAdminKey } from '../middleware/adminAuth.js';

--- a/backend/src/routes/collaborators.ts
+++ b/backend/src/routes/collaborators.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { contractQuery, adminInvoke } from "../lib/stellar.js";
-
+import { requireAdminKey } from "../middleware/adminAuth.js";
 export const collaboratorRouter = Router();
 
 export interface CollaboratorShare {

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -76,6 +76,33 @@ export function createMeterRouter(stellar: StellarService) {
     }),
   );
 
+  /** GET /api/meters/expiring — return meters expiring within the next 24 hours */
+  meterRouter.get(
+    "/expiring",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const windowHours = Number(req.query.hours ?? 24);
+      if (isNaN(windowHours) || windowHours <= 0) {
+        return res.status(400).json({ error: "Invalid hours parameter" });
+      }
+
+      const result = await stellar.query("get_all_meters", []);
+      const allMeters = (StellarSdk.scValToNative(result) as any[]) ?? [];
+
+      const nowMs = Date.now();
+      const thresholdMs = nowMs + windowHours * 60 * 60 * 1000;
+
+      const expiring = allMeters.filter((m: any) => {
+        if (!m.expires_at) return false;
+        // Assume expires_at is in seconds since epoch based on Stellar types
+        const expiresMs = Number(m.expires_at) * 1000;
+        return expiresMs > nowMs && expiresMs <= thresholdMs;
+      });
+
+      res.json({ expiring, count: expiring.length });
+    })
+  );
+
   /** GET /api/meters/:id/status — lightweight status poll */
   meterRouter.get(
     "/:id/status",
@@ -98,6 +125,8 @@ export function createMeterRouter(stellar: StellarService) {
       } catch {
         return res.status(500).json({ error: "Query failed", code: "CONTRACT_ERROR" });
       }
+    }),
+  );
   /** GET /api/meters/owner/:address — list all meters for an owner (must be before /:id) */
   meterRouter.get(
     "/owner/:address",

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -60,7 +60,6 @@ webhookRouter.post(
       StellarSdk.nativeToScVal({ [plan]: null }),
     ]);
     paymentVolume.inc(amount_xlm);
-    activeMeters.inc();
     return res.status(200).json({ hash });
   }),
 );


### PR DESCRIPTION
This PR fixes issues #468, #467, #466, and #465 as requested.

- Removes unconditional activeMeters.inc() metric increment on payments (fixes #468).
- Reuses existing MQTT client in /health check to prevent connection leak (fixes #467).
- Cleans up duplicate imports and missing syntax errors throughout the codebase (fixes #466).
- Adds GET /api/meters/expiring endpoint to fetch expiring meters (fixes #465).