### PR TITLE
feat: add meter plan/renew/delete API endpoints and keyboard shortcut for search

### DIFF
--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -114,6 +114,31 @@ export function createMeterRouter(stellar: StellarService) {
     }),
   );
 
+  /** GET /api/meters/:id/plan — current plan type and expiry timestamp */
+  meterRouter.get(
+    "/:id/plan",
+    cacheFor(5_000),
+    asyncHandler(async (req, res) => {
+      const meterId = req.params.id;
+      let meter: any;
+      try {
+        const result = await stellar.query("get_meter", [
+          StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        ]);
+        meter = StellarSdk.scValToNative(result);
+      } catch {
+        return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+      }
+      if (!meter) return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+      return res.json({
+        meter_id: meterId,
+        plan: meter.plan,
+        expires_at: meter.expires_at,
+        active: meter.active,
+      });
+    }),
+  );
+
   /** GET /api/meters/:id — get meter status */
   meterRouter.get(
     "/:id",
@@ -322,6 +347,64 @@ export function createMeterRouter(stellar: StellarService) {
       } catch (err: any) {
         return res.status(500).json({ error: err.message, code: "CONTRACT_ERROR" });
       }
+    }),
+  );
+
+  /** DELETE /api/meters/:id — admin deregisters a meter */
+  meterRouter.delete(
+    "/:id",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const meterId = req.params.id;
+      let meter: any;
+      try {
+        const result = await stellar.query("get_meter", [
+          StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        ]);
+        meter = StellarSdk.scValToNative(result);
+      } catch {
+        return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+      }
+      if (!meter) return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+      const hash = await stellar.invoke("deregister_meter", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+      ]);
+      invalidateCache(`/api/meters/${meterId}`);
+      return res.json({ hash, meter_id: meterId, deleted: true });
+    }),
+  );
+
+  /** POST /api/meters/:id/renew — trigger plan renewal payment for an expired meter */
+  meterRouter.post(
+    "/:id/renew",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const meterId = req.params.id;
+      const { amount_xlm, plan } = req.body as { amount_xlm: unknown; plan: unknown };
+
+      const amount = Number(amount_xlm);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        return res.status(400).json({ error: "amount_xlm must be a positive number", code: "VALIDATION_ERROR" });
+      }
+
+      let meter: any;
+      try {
+        const result = await stellar.query("get_meter", [
+          StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        ]);
+        meter = StellarSdk.scValToNative(result);
+      } catch {
+        return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+      }
+      if (!meter) return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+
+      const planValue = plan ?? meter.plan;
+      const hash = await stellar.invoke("make_payment", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        StellarSdk.nativeToScVal(BigInt(Math.round(amount * 1e7)), { type: "i128" }),
+        StellarSdk.nativeToScVal(planValue, { type: "symbol" }),
+      ]);
+      return res.json({ hash, meter_id: meterId, renewed: true });
     }),
   );
 

--- a/frontend/src/app/dashboard/provider/page.tsx
+++ b/frontend/src/app/dashboard/provider/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Navbar from "@/components/Navbar";
 import { Skeleton } from "@/components/Skeleton";
@@ -31,6 +31,19 @@ export default function ProviderDashboardPage() {
 
   const [meters, setMeters] = useState<MeterData[]>([]);
   const [fetching, setFetching] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== "/") return;
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const addressInvalid =
     ownerAddress.trim().length > 0 && !isValidStellarAddress(ownerAddress.trim());
@@ -261,11 +274,12 @@ export default function ProviderDashboardPage() {
             </button>
           </div>
 
-          {/* Search Input */}
+          {/* Search Input — focus with "/" shortcut */}
           <div className="relative mb-4">
             <input
+              ref={searchInputRef}
               type="search"
-              placeholder="Search by owner address…"
+              placeholder="Search by owner address… (press / to focus)"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               onKeyDown={(e) => {


### PR DESCRIPTION
## Summary

This PR implements four issues across the backend API and provider dashboard frontend.

---

### Closes #457 — Keyboard shortcut to focus meter search input

**File:** `frontend/src/app/dashboard/provider/page.tsx`

Added a `useRef` on the search input and a `useEffect` that attaches a global `keydown` listener. Pressing `/` when focus is not inside any `INPUT` or `TEXTAREA` moves focus directly to the meter search input. Pressing `Escape` still clears the search. The placeholder text was updated to hint at the shortcut (`press / to focus`). The existing `focus:border-solar-yellow` Tailwind class provides the visible focus ring for accessibility.

---

### Closes #458 — `GET /api/meters/:id/plan` endpoint

**File:** `backend/src/routes/meters.ts`

Added a new sub-resource route `GET /:id/plan` placed **before** the generic `/:id` handler so Express routes it correctly. Wrapped with `cacheFor(5_000)` for a 5-second response cache. Returns:

```json
{ "meter_id": "...", "plan": "...", "expires_at": 0, "active": true }
```

Returns `404` when the meter does not exist.

---

### Closes #459 — `DELETE /api/meters/:id` endpoint

**File:** `backend/src/routes/meters.ts`

Added `DELETE /:id` protected by `requireAdminKey`. First queries the contract to confirm the meter exists (returns `404` if not), then invokes the `deregister_meter` contract function, and finally calls `invalidateCache` to evict the stale cache entry for that meter. Returns:

```json
{ "hash": "...", "meter_id": "...", "deleted": true }
```

---

### Closes #460 — `POST /api/meters/:id/renew` endpoint

**File:** `backend/src/routes/meters.ts`

Added `POST /:id/renew` protected by `requireAdminKey`. Accepts `{ amount_xlm, plan }` in the request body. Validates that `amount_xlm` is a positive finite number (returns `400` otherwise), verifies the meter exists (returns `404` otherwise), then re-invokes the `make_payment` contract function using the provided plan or falling back to the meter's current plan. Returns:

```json
{ "hash": "...", "meter_id": "...", "renewed": true }
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)