### PR TITLE
fix(backend): close unclosed /:id/status handler + add provider reven…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import { logger } from "./lib/logger.js";
 import { writeLimiter, readLimiter } from "./middleware/rateLimit.js";
 import { collaboratorRouter } from "./routes/collaborators.js";
 import { statsRouter } from "./routes/stats.js";
+import { providerRouter } from "./routes/provider.js";
 import { startIoTBridge } from "./iot/bridge.js";
 import { startLimitWatcher } from "./iot/limitWatcher.js";
 import { logger } from "./lib/logger.js";
@@ -157,6 +158,7 @@ app.use("/api/collaborators", collaboratorRouter);
 app.use("/api/allowlist", allowlistRouter);
 app.use("/api/collaborators", collaboratorRouter);
 app.use("/api/stats", statsRouter);
+app.use("/api/provider", providerRouter);
 app.use("/api/metrics", metricsRouter);
 
 // #420: GET /api/health — version, uptime, dependency status

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -98,6 +98,9 @@ export function createMeterRouter(stellar: StellarService) {
       } catch {
         return res.status(500).json({ error: "Query failed", code: "CONTRACT_ERROR" });
       }
+    }),
+  );
+
   /** GET /api/meters/owner/:address — list all meters for an owner (must be before /:id) */
   meterRouter.get(
     "/owner/:address",

--- a/backend/src/routes/provider.ts
+++ b/backend/src/routes/provider.ts
@@ -1,0 +1,46 @@
+import { Router } from "express";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { stellarService } from "../lib/stellar.js";
+import { asyncHandler } from "../lib/asyncHandler.js";
+import { requireAdminKey } from "../middleware/adminAuth.js";
+
+export const providerRouter = Router();
+
+/**
+ * POST /api/provider/withdraw-revenue
+ *
+ * Allows the energy provider (admin) to withdraw accumulated revenue from
+ * the smart contract vault. Calls `withdraw_revenue` on the Soroban contract.
+ *
+ * Body: { provider: string, amount: number }
+ *
+ * Closes #90.
+ */
+providerRouter.post(
+  "/withdraw-revenue",
+  requireAdminKey,
+  asyncHandler(async (req, res) => {
+    const { provider, amount } = req.body as { provider: unknown; amount: unknown };
+
+    if (!provider || typeof provider !== "string") {
+      return res.status(400).json({ error: "provider address is required", code: "VALIDATION_ERROR" });
+    }
+    try {
+      StellarSdk.StrKey.decodeEd25519PublicKey(provider);
+    } catch {
+      return res.status(400).json({ error: "Invalid Stellar provider address", code: "VALIDATION_ERROR" });
+    }
+
+    const amountNum = Number(amount);
+    if (!Number.isInteger(amountNum) || amountNum <= 0) {
+      return res.status(400).json({ error: "amount must be a positive integer (stroops)", code: "VALIDATION_ERROR" });
+    }
+
+    const hash = await stellarService.invoke("withdraw_revenue", [
+      StellarSdk.nativeToScVal(provider, { type: "address" }),
+      StellarSdk.nativeToScVal(BigInt(amountNum), { type: "i128" }),
+    ]);
+
+    res.json({ hash, provider, amount: amountNum });
+  }),
+);


### PR DESCRIPTION
…ue withdrawal (#256, #90)

--- Issue #256: refactor(backend): fix nested route registration bug in meters.ts ---

Root cause:
The GET /:id/status handler in createMeterRouter (backend/src/routes/meters.ts) was missing its closing }); after the catch block. Express route handlers are registered by calling meterRouter.get/post(...), but because the asyncHandler callback was never closed, every route registration that followed — GET /owner/:address, GET /:id, GET /:id/access, POST /, and POST /:id/usage — was lexically nested inside the /:id/status callback body rather than at the router's top level.

This caused two distinct bugs:
  1. All routes after /:id/status were only registered on the first request that matched /:id/status, and re-registered on every subsequent match, stacking duplicate handlers that could return duplicate responses.
  2. POST / (register meter) was completely unreachable until at least one /:id/status request had been made, because the router had no knowledge of the route's existence before that point.

Fix applied:
Added the missing closing }); to the /:id/status asyncHandler, directly after the catch block that returns the 500 CONTRACT_ERROR response. This promotes all subsequent route registrations back to the router's top level where they belong, restoring correct, deterministic routing for every handler in the file.

Files changed: backend/src/routes/meters.ts

--- Issue #90: feat(api): add POST /api/provider/withdraw-revenue endpoint ---

Background:
The Soroban smart contract (contracts/solar_grid/src/lib.rs) already implements a withdraw_revenue(provider, amount) function that deducts from the provider's tracked ProviderRevenue storage key and transfers tokens back to the provider address. However, there was no backend REST endpoint exposing this function, so energy providers had no HTTP interface to trigger withdrawals without constructing Soroban transactions manually.

Implementation:
  - Created backend/src/routes/provider.ts with a single route: POST /api/provider/withdraw-revenue The handler: • Requires the X-Admin-Key header (requireAdminKey middleware) — only the admin/provider may call this. • Validates that provider is a well-formed Stellar Ed25519 public key via StellarSdk.StrKey.decodeEd25519PublicKey. • Validates that amount is a positive integer (stroops). • Calls stellarService.invoke('withdraw_revenue', [provider_scval, amount_i128]) which submits a signed transaction to the Soroban contract. • Returns { hash, provider, amount } on success.
  - Registered the new router in backend/src/index.ts: import { providerRouter } from './routes/provider.js'; app.use('/api/provider', providerRouter);

The contract's withdraw_revenue function enforces that the caller matches the stored admin address (ContractError::Unauthorized if not), so even if the X-Admin-Key middleware were bypassed, the on-chain guard still protects funds.

Files changed: backend/src/routes/provider.ts (new), backend/src/index.ts

Closes #256
Closes #90

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other: <!-- describe -->

## Changes Made

<!-- Bullet-point list of the key changes. Focus on the *why*, not just the *what*. -->

-
-

## How to Test

<!-- Steps a reviewer can follow to verify the change works correctly. -->

1.
2.

## Checklist

- [ ] Code builds without errors (`cargo build` / `npm run build`)
- [ ] No TypeScript errors (`tsc --noEmit`)
- [ ] Rust code is formatted (`cargo fmt`) and lint-clean (`cargo clippy -- -D warnings`)
- [ ] No unintended breaking changes to existing functionality
- [ ] PR targets the `main` branch and is rebased on the latest upstream

## Screenshots (if applicable)

<!-- Delete this section if not relevant. -->
