### PR TITLE
fix(backend): signal handling and missing environment variable warnings

### DIFF
--- a/backend/src/lib/usageEvents.ts
+++ b/backend/src/lib/usageEvents.ts
@@ -216,6 +216,14 @@ export function startUsageEventRetryWorker() {
     void retryQueuedUsageEvents();
   }, RETRY_INTERVAL_MS);
   retryTimer.unref?.();
+
+  process.on('SIGTERM', () => {
+    if (retryTimer) {
+      clearInterval(retryTimer);
+      retryTimer = undefined;
+      logger.info('Usage event retry worker stopped on SIGTERM');
+    }
+  });
 }
 
 export async function retryQueuedUsageEvents() {

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -3,6 +3,7 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import { stellarService } from "../lib/stellar.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
 import { register } from "../lib/metrics.js";
+import { logger } from "../lib/logger.js";
 
 export const statsRouter = Router();
 
@@ -33,6 +34,8 @@ statsRouter.get("/", asyncHandler(async (_req, res) => {
       StellarSdk.nativeToScVal(adminAddr, { type: "address" }),
     ]);
     revenue = Number(StellarSdk.scValToNative(rev));
+  } else {
+    logger.warn('ADMIN_ADDRESS environment variable is not set; provider revenue query skipped');
   }
 
   const data = {


### PR DESCRIPTION
## Summary
This PR addresses two backend stability and observability issues:

1. **Issue #469**: Missing warning when ADMIN_ADDRESS environment variable is unset, causing silent failure of revenue queries
2. **Issue #470**: usageEvents retry worker does not stop on SIGTERM, preventing graceful shutdown and causing unclean process termination

## Changes Implemented

### Issue #469: Silent Revenue Query Failure in stats.ts
**File**: `backend/src/routes/stats.ts`

- Added logger import
- Added warning log when `ADMIN_ADDRESS` environment variable is not set
- The `/api/stats` endpoint now warns administrators when the provider revenue query is skipped due to missing configuration
- Prevents silent misleading of zero revenue in dashboards when the contract holds non-zero balances

**Before**:
typescript
let revenue = 0;
const adminAddr = process.env.ADMIN_ADDRESS;
if (adminAddr) {
 const rev = await stellarService.query("get_provider_revenue", [...]);
 revenue = Number(StellarSdk.scValToNative(rev));
}

**After**:
typescript
let revenue = 0;
const adminAddr = process.env.ADMIN_ADDRESS;
if (adminAddr) {
 const rev = await stellarService.query("get_provider_revenue", [...]);
 revenue = Number(StellarSdk.scValToNative(rev));
} else {
 logger.warn('ADMIN_ADDRESS environment variable is not set; provider revenue query skipped');
}

### Issue #470: Unhandled SIGTERM in usageEvents Retry Worker
**File**: `backend/src/lib/usageEvents.ts`

- Registered a `process.on('SIGTERM')` handler in `startUsageEventRetryWorker()`
- Clears the setInterval timer when SIGTERM is received
- Logs info message when worker stops cleanly
- Prevents process from hanging for the full retry interval duration during shutdown (e.g., Docker/Kubernetes termination)

**Changes**:
typescript
export function startUsageEventRetryWorker() {
 if (retryTimer) {
   return;
 }

 logger.info('Usage event retry worker started', { intervalMs: RETRY_INTERVAL_MS, maxRetryAttempts: MAX_RETRY_ATTEMPTS });
 retryTimer = setInterval(() => {
   void retryQueuedUsageEvents();
 }, RETRY_INTERVAL_MS);
 retryTimer.unref?.();

 // NEW: Handle graceful shutdown
 process.on('SIGTERM', () => {
   if (retryTimer) {
     clearInterval(retryTimer);
     retryTimer = undefined;
     logger.info('Usage event retry worker stopped on SIGTERM');
   }
 });
}

## Testing
- Verified SIGTERM handler properly clears interval and allows process to exit immediately
- Verified warning logs are emitted when ADMIN_ADDRESS is unset
- No changes to contract interaction logic or data structures

## Impact
- **Observability**: Administrators now see clear warnings when configuration is missing
- **Stability**: Backend gracefully shuts down without hanging when receiving SIGTERM signals
- **Operations**: Improves Docker/Kubernetes deployment reliability with faster container termination

Closes #469
Closes #470