### PR TITLE
feat: plan selector, history empty state, skeleton loaders, meter history link

### DIFF
--- a/frontend/src/app/dashboard/user/page.tsx
+++ b/frontend/src/app/dashboard/user/page.tsx
@@ -6,7 +6,6 @@ import Navbar from "@/components/Navbar";
 import { SkeletonCard } from "@/components/SkeletonCard";
 import { Skeleton } from "@/components/Skeleton";
 import UsageChart, { type UsageDataPoint } from "@/components/UsageChart";
-import { SkeletonCard } from "@/components/SkeletonCard";
 import { useWalletStore } from "@/store/walletStore";
 import { getMeter, getMetersByOwner, type MeterData } from "@/services/meterService";
 import { parseWalletError } from "@/lib/errors";
@@ -176,10 +175,10 @@ function MeterCard({ meterId, meter }: { meterId: string; meter: MeterData }) {
           Top Up
         </Link>
         <Link
-          href="/history"
+          href={`/history?meterId=${meterId}`}
           className="rounded-lg border border-white/10 px-4 py-2 text-xs text-gray-300 hover:border-solar-yellow hover:text-solar-yellow transition"
         >
-          History
+          View history
         </Link>
       </div>
     </div>

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import Navbar from "@/components/Navbar";
+import { Skeleton } from "@/components/Skeleton";
 import { useWalletStore } from "@/store/walletStore";
 import { useToast } from "@/components/ToastProvider";
 import {
@@ -29,6 +31,7 @@ export default function HistoryPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryPage = parseInt(searchParams.get("page") || "1");
+  const filterMeterId = searchParams.get("meterId");
 
   const [records, setRecords] = useState<PaymentRecord[]>([]);
   const [pagination, setPagination] = useState({ page: 1, pages: 1, total: 0 });
@@ -130,7 +133,7 @@ export default function HistoryPage() {
     }
   }
 
-  const sorted = [...records].sort((a, b) => {
+  const sorted = [...records].filter((r) => !filterMeterId || r.meterId === filterMeterId).sort((a, b) => {
     let cmp = 0;
     if (sortField === "date") cmp = new Date(a.date).getTime() - new Date(b.date).getTime();
     else if (sortField === "amountXlm") cmp = a.amountXlm - b.amountXlm;
@@ -152,9 +155,22 @@ export default function HistoryPage() {
       <Navbar />
       <main className="min-h-screen px-4 py-8 max-w-5xl mx-auto">
         <h1 className="text-2xl sm:text-3xl font-bold text-solar-yellow mb-1">Payment History</h1>
-        <p className="text-gray-400 mb-6 text-sm">
+        <p className="text-gray-400 mb-3 text-sm">
           All <code className="text-solar-yellow">make_payment</code> transactions for your wallet.
         </p>
+        {filterMeterId && (
+          <div className="mb-4 inline-flex items-center gap-2 rounded-lg border border-solar-yellow/30 bg-solar-yellow/10 px-3 py-1.5 text-xs text-solar-yellow">
+            <span>Filtered by meter:</span>
+            <span className="font-mono font-semibold">{filterMeterId}</span>
+            <Link
+              href="/history"
+              className="ml-1 rounded px-1 hover:bg-solar-yellow/20 transition"
+              aria-label="Clear filter"
+            >
+              ✕
+            </Link>
+          </div>
+        )}
 
         {!address && (
           <div className="rounded-lg border border-white/10 bg-solar-accent p-8 text-center text-gray-400 text-sm">
@@ -172,10 +188,17 @@ export default function HistoryPage() {
           <>
             {/* ── Mobile card list (hidden on sm+) ── */}
             <div className="sm:hidden space-y-3">
-              {loading && <p className="text-center text-gray-500 py-10">Loading…</p>}
-              {!loading && sorted.length === 0 && (
-                <p className="text-center text-gray-500 py-10">No payment records found.</p>
-              )}
+              {loading && [0, 1, 2, 3].map((i) => (
+                <div key={i} className="rounded-xl border border-white/10 bg-solar-accent p-4 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Skeleton width="35%" height={18} />
+                    <Skeleton width="22%" height={22} />
+                  </div>
+                  <Skeleton width="50%" height={12} />
+                  <Skeleton width="60%" height={12} />
+                </div>
+              ))}
+              {!loading && sorted.length === 0 && <EmptyState />}
               {!loading &&
                 sorted.map((r, i) => (
                   <div
@@ -230,18 +253,18 @@ export default function HistoryPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {loading && (
-                    <tr>
-                      <td colSpan={5} className="px-4 py-10 text-center text-gray-500">
-                        Loading…
-                      </td>
+                  {loading && [0, 1, 2, 3, 4].map((i) => (
+                    <tr key={i} className="border-t border-white/5">
+                      <td className="px-3 py-3"><Skeleton width="80%" height={14} /></td>
+                      <td className="px-3 py-3"><Skeleton width="65%" height={14} /></td>
+                      <td className="px-3 py-3"><Skeleton width="50%" height={14} /></td>
+                      <td className="px-3 py-3"><Skeleton width="55%" height={20} /></td>
+                      <td className="px-3 py-3"><Skeleton width="70%" height={14} /></td>
                     </tr>
-                  )}
+                  ))}
                   {!loading && sorted.length === 0 && (
                     <tr>
-                      <td colSpan={5} className="px-4 py-10 text-center text-gray-500">
-                        No payment records found.
-                      </td>
+                      <td colSpan={5}><EmptyState /></td>
                     </tr>
                   )}
                   {!loading &&
@@ -321,6 +344,42 @@ export default function HistoryPage() {
         )}
       </main>
     </>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+      <svg
+        width="80"
+        height="80"
+        viewBox="0 0 80 80"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="40" cy="40" r="38" stroke="#374151" strokeWidth="2" />
+        <path
+          d="M40 22 L40 42 M34 30 L40 22 L46 30"
+          stroke="#F59E0B"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <rect x="26" y="44" width="28" height="4" rx="2" fill="#374151" />
+        <rect x="30" y="52" width="20" height="4" rx="2" fill="#374151" />
+      </svg>
+      <h3 className="mt-5 text-base font-semibold text-white">No payment history yet</h3>
+      <p className="mt-1.5 text-sm text-gray-400 max-w-xs">
+        Your transactions will appear here once you make a payment.
+      </p>
+      <Link
+        href="/pay"
+        className="mt-6 rounded-lg bg-solar-yellow px-5 py-2.5 text-sm font-semibold text-solar-dark hover:opacity-90 transition"
+      >
+        Make your first payment
+      </Link>
+    </div>
   );
 }
 

--- a/frontend/src/app/pay/page.tsx
+++ b/frontend/src/app/pay/page.tsx
@@ -19,6 +19,12 @@ const PLANS: { value: Plan; label: string; desc: string }[] = [
   { value: "Usage", label: "Usage-Based", desc: "Pay per kWh consumed" },
 ];
 
+const PLAN_AMOUNT_HINTS: Record<Plan, string> = {
+  Daily: "Suggested: 10 XLM/day",
+  Weekly: "Suggested: 50 XLM/week",
+  Usage: "Amount (billed per kWh consumed)",
+};
+
 export default function PayPage() {
   const { address, connect } = useWalletStore();
   const { meterId, plan, setMeterId, setPlan } = usePaymentStore();
@@ -242,43 +248,6 @@ export default function PayPage() {
                   />
                 </div>
 
-                {/* Amount */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                    Amount (XLM)
-                  </label>
-                  <input
-                    type="number"
-                    value={amount}
-                    onChange={(e) => { setAmount(e.target.value); setTxHash(null); }}
-                    placeholder="0.00"
-                    min="0.0000001"
-                    step="any"
-                    required
-                    className="w-full rounded-lg border border-white/10 bg-solar-dark px-4 py-2.5 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
-                  />
-                  {xlmRate && amount && (
-                    <div className="mt-2 flex items-center justify-between">
-                      <p className="text-xs text-gray-400">
-                        ≈ {(parseFloat(amount) * xlmRate).toLocaleString('en-NG', { 
-                          style: 'currency', 
-                          currency: currency 
-                        })}
-                      </p>
-                      <select
-                        value={currency}
-                        onChange={(e) => handleCurrencyChange(e.target.value)}
-                        className="text-xs bg-solar-dark border border-white/10 rounded px-2 py-1 text-gray-300"
-                      >
-                        <option value="NGN">NGN</option>
-                        <option value="KES">KES</option>
-                        <option value="GHS">GHS</option>
-                        <option value="USD">USD</option>
-                      </select>
-                    </div>
-                  )}
-                </div>
-
                 {/* Plan */}
                 <div>
                   <label className="block text-sm font-medium text-gray-300 mb-2">Billing Plan</label>
@@ -299,6 +268,44 @@ export default function PayPage() {
                       </button>
                     ))}
                   </div>
+                </div>
+
+                {/* Amount */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                    Amount (XLM)
+                  </label>
+                  <input
+                    type="number"
+                    value={amount}
+                    onChange={(e) => { setAmount(e.target.value); setTxHash(null); }}
+                    placeholder="0.00"
+                    min="0.0000001"
+                    step="any"
+                    required
+                    className="w-full rounded-lg border border-white/10 bg-solar-dark px-4 py-2.5 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+                  />
+                  <p className="mt-1.5 text-xs text-gray-500">{PLAN_AMOUNT_HINTS[plan]}</p>
+                  {xlmRate && amount && (
+                    <div className="mt-2 flex items-center justify-between">
+                      <p className="text-xs text-gray-400">
+                        ≈ {(parseFloat(amount) * xlmRate).toLocaleString('en-NG', {
+                          style: 'currency',
+                          currency: currency
+                        })}
+                      </p>
+                      <select
+                        value={currency}
+                        onChange={(e) => handleCurrencyChange(e.target.value)}
+                        className="text-xs bg-solar-dark border border-white/10 rounded px-2 py-1 text-gray-300"
+                      >
+                        <option value="NGN">NGN</option>
+                        <option value="KES">KES</option>
+                        <option value="GHS">GHS</option>
+                        <option value="USD">USD</option>
+                      </select>
+                    </div>
+                  )}
                 </div>
 
               {/* Submit */}

--- a/frontend/src/components/CollaboratorTable.tsx
+++ b/frontend/src/components/CollaboratorTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useToast } from "@/components/ToastProvider";
+import { Skeleton } from "@/components/Skeleton";
 
 export interface Collaborator {
   address: string;
@@ -10,13 +11,14 @@ export interface Collaborator {
 
 interface Props {
   collaborators: Collaborator[];
+  loading?: boolean;
   onAdd: (address: string, basisPoints: number) => Promise<void>;
   onRemove: (address: string) => Promise<void>;
 }
 
 import styles from './CollaboratorTable.module.css';
 
-export default function CollaboratorTable({ collaborators }: Props) {
+export default function CollaboratorTable({ collaborators, loading }: Props) {
   const [copied, setCopied] = useState<string | null>(null);
   const [newAddress, setNewAddress] = useState("");
   const [newBasisPoints, setNewBasisPoints] = useState("");
@@ -27,6 +29,31 @@ export default function CollaboratorTable({ collaborators }: Props) {
     navigator.clipboard.writeText(address);
     setCopied(address);
     setTimeout(() => setCopied(null), 1500);
+  }
+
+  if (loading) {
+    return (
+      <div className="card overflow-x-auto">
+        <span className="badge">Collaborators</span>
+        <table className="collab-table">
+          <thead>
+            <tr>
+              <th>Address</th>
+              <th className="text-right">Share</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[0, 1, 2].map((i) => (
+              <tr key={i}>
+                <td className="py-3"><Skeleton width="70%" height={14} /></td>
+                <td className="py-3"><Skeleton width="40%" height={14} /></td>
+                <td className="py-3" style={{ textAlign: "right" }}><Skeleton width="60px" height={28} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
   }
 
   // Empty state — helpful message instead of silent null


### PR DESCRIPTION
## Summary

This PR implements four frontend enhancements across the pay, history, and dashboard pages.

---

### Closes #453 — Plan selector on pay page before amount input

- Moved the **plan selector** (Daily / Weekly / Usage-Based) to appear **before** the amount input field in the payment form so users choose their billing plan first.
- Added plan-specific helper text below the amount field (e.g. `Suggested: 10 XLM/day` for Daily, `Suggested: 50 XLM/week` for Weekly, `Amount (billed per kWh consumed)` for Usage).
- Selected plan is visually highlighted with a solar-yellow border and background; unselected options retain neutral styling.
- Selection calls `usePaymentStore.setPlan` as required.

---

### Closes #454 — Empty state illustration on history page

- Added an `EmptyState` component rendered when the payments array is empty and loading is `false` — it shows an inline SVG illustration, a **"No payment history yet"** heading, a short description, and a **"Make your first payment"** CTA button linking to `/pay`.
- While data is loading, **skeleton placeholder rows** are shown instead (4 mobile cards, 5 desktop table rows) — the empty state is never shown during loading.

---

### Closes #455 — Skeleton loaders in CollaboratorTable

- Added a `loading?: boolean` prop to `CollaboratorTable`.
- Imported the existing `Skeleton` component.
- When `loading` is `true`, renders **3 skeleton rows** matching the column layout (Address | Share | Action) before real data or the empty state appears, preventing layout shift.

---

### Closes #456 — Meter card "View history" link filtered by meter ID

- Changed the **"History" link** on each `MeterCard` (dashboard user page) from `/history` to `/history?meterId=<id>` so each card deep-links into that meter's payment records.
- Updated `history/page.tsx` to read the `meterId` query param via `useSearchParams` and **client-side filter** the displayed records to only those matching that meter.
- Added a dismissible **filter chip** below the page heading showing the active meter filter with a clear (✕) link back to `/history`.
- Fixed a duplicate `SkeletonCard` import in the dashboard page that would have caused a compile error.

---

## Files changed

| File | Issues |
|------|--------|
| `frontend/src/app/pay/page.tsx` | #453 |
| `frontend/src/app/history/page.tsx` | #454, #456 |
| `frontend/src/components/CollaboratorTable.tsx` | #455 |
| `frontend/src/app/dashboard/user/page.tsx` | #456 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)