### PR TITLE
471 472 473 474 frontend fixes

### DIFF
--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -102,14 +102,20 @@ export default function HistoryPage() {
           PAGE_SIZE,
           serverSort,
         );
+        if (!data || !data.payments) {
+          throw new Error("Invalid response: missing payments data");
+        }
         setRecords(data.payments);
         setPagination({
-          page: data.pagination.page,
-          pages: data.pagination.pages,
-          total: data.pagination.total,
+          page: data.pagination?.page ?? 1,
+          pages: data.pagination?.pages ?? 1,
+          total: data.pagination?.total ?? 0,
         });
       } catch (e: any) {
-        setError(e.message ?? "Failed to load payment history");
+        const errorMsg = e.message ?? "Failed to load payment history";
+        setError(errorMsg);
+        setRecords([]);
+        setPagination({ page: 1, pages: 1, total: 0 });
       } finally {
         setLoading(false);
       }

--- a/frontend/src/components/CollaboratorTable.tsx
+++ b/frontend/src/components/CollaboratorTable.tsx
@@ -12,11 +12,13 @@ interface Props {
   collaborators: Collaborator[];
   onAdd: (address: string, basisPoints: number) => Promise<void>;
   onRemove: (address: string) => Promise<void>;
+  onRefresh?: () => Promise<void>;
 }
 
 import styles from './CollaboratorTable.module.css';
 
-export default function CollaboratorTable({ collaborators }: Props) {
+export default function CollaboratorTable({ collaborators, onAdd, onRemove, onRefresh }: Props) {
+  const { showToast } = useToast();
   const [copied, setCopied] = useState<string | null>(null);
   const [newAddress, setNewAddress] = useState("");
   const [newBasisPoints, setNewBasisPoints] = useState("");
@@ -27,6 +29,59 @@ export default function CollaboratorTable({ collaborators }: Props) {
     navigator.clipboard.writeText(address);
     setCopied(address);
     setTimeout(() => setCopied(null), 1500);
+  }
+
+  async function handleAddSubmit() {
+    if (!newAddress.trim() || !newBasisPoints.trim()) {
+      showToast({
+        variant: "error",
+        title: "Invalid input",
+        description: "Please enter both address and basis points.",
+      });
+      return;
+    }
+
+    setIsAdding(true);
+    try {
+      await onAdd(newAddress.trim(), Number(newBasisPoints));
+      setNewAddress("");
+      setNewBasisPoints("");
+      if (onRefresh) await onRefresh();
+      showToast({
+        variant: "success",
+        title: "Collaborator added",
+        description: "The collaborator list has been updated.",
+      });
+    } catch (err) {
+      showToast({
+        variant: "error",
+        title: "Failed to add collaborator",
+        description: err instanceof Error ? err.message : "Failed to add collaborator",
+      });
+    } finally {
+      setIsAdding(false);
+    }
+  }
+
+  async function handleRemove(address: string) {
+    setIsRemoving(address);
+    try {
+      await onRemove(address);
+      if (onRefresh) await onRefresh();
+      showToast({
+        variant: "success",
+        title: "Collaborator removed",
+        description: "The collaborator list has been updated.",
+      });
+    } catch (err) {
+      showToast({
+        variant: "error",
+        title: "Failed to remove collaborator",
+        description: err instanceof Error ? err.message : "Failed to remove collaborator",
+      });
+    } finally {
+      setIsRemoving(null);
+    }
   }
 
   // Empty state — helpful message instead of silent null

--- a/frontend/src/store/paymentStore.ts
+++ b/frontend/src/store/paymentStore.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 
 interface PaymentFormState {
   meterId: string;
@@ -11,17 +10,10 @@ interface PaymentFormState {
   reset: () => void;
 }
 
-export const usePaymentStore = create<PaymentFormState>()(
-  persist(
-    (set) => ({
-      meterId: "",
-      plan: "Daily",
-      setMeterId: (id: string) => set({ meterId: id }),
-      setPlan: (plan: "Daily" | "Weekly" | "Usage") => set({ plan }),
-      reset: () => set({ meterId: "", plan: "Daily" }),
-    }),
-    {
-      name: "payment-form",
-    }
-  )
-);
+export const usePaymentStore = create<PaymentFormState>((set) => ({
+  meterId: "",
+  plan: "Daily",
+  setMeterId: (id: string) => set({ meterId: id }),
+  setPlan: (plan: "Daily" | "Weekly" | "Usage") => set({ plan }),
+  reset: () => set({ meterId: "", plan: "Daily" }),
+}));

--- a/frontend/src/store/walletStore.ts
+++ b/frontend/src/store/walletStore.ts
@@ -37,6 +37,9 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   connect: async () => {
     set({ connectError: null });
     try {
+      if (typeof window === "undefined" || !(window as any).freighter) {
+        throw new Error("Freighter extension is not installed. Please install it to continue.");
+      }
       const kit = buildKit();
       await kit.openModal({
         onWalletSelected: async (option) => {


### PR DESCRIPTION
## Summary

Fix four frontend security and UX issues across payment store, wallet connection, payment history, and collaborator management.

## Changes

### Issue #471: Handle 502 RPC errors in history page
**File:** `frontend/src/app/history/page.tsx`
- Added null/undefined checks before destructuring `payments` from response
- Reset records and pagination state on error
- Display user-friendly error message instead of crashing
- **Why:** When Stellar RPC is unavailable, the API returns 502 with error object. Without response validation, destructuring fails with `TypeError: Cannot destructure property 'payments' of undefined`

### Issue #472: Guard against Freighter extension not being installed
**File:** `frontend/src/store/walletStore.ts`
- Added `window.freighter` presence check before calling wallet API
- Throw descriptive error for missing extension
- Existing error handler catches and displays user-friendly message
- **Why:** Prevents `ReferenceError` crash when calling `kit.openModal()` on systems without Freighter installed

### Issue #473: CollaboratorTable refreshes data after add/remove
**File:** `frontend/src/components/CollaboratorTable.tsx`
- Implemented missing `handleAddSubmit()` and `handleRemove()` functions
- Added `onRefresh` callback prop to reload collaborator list after mutations
- Added toast notifications for success/error feedback
- Removed stale data by refetching from parent component after operations
- **Why:** Without refetching, removed collaborators remained visible in the table until manual page refresh

### Issue #474: Remove persist middleware from paymentStore
**File:** `frontend/src/store/paymentStore.ts`
- Removed `zustand/middleware` persist import
- Removed persist wrapper from store creation
- Store now only maintains state in memory (cleared on session end)
- **Why:** Sensitive `meterId` was persisting to `localStorage` indefinitely, allowing a subsequent user on a shared device to see the previous user's meter ID pre-filled in the payment form

## Testing Checklist

- [ ] History page displays error message gracefully when RPC is unavailable
- [ ] Payment form no longer pre-fills meter ID on new sessions
- [ ] Wallet connect shows error when Freighter is not installed
- [ ] Adding collaborator triggers list refresh and shows success toast
- [ ] Removing collaborator triggers list refresh and shows success toast

## Closes 
Closes #471
Closes  #472
Closes #473 
 Closes #474


