### PR TITLE
feat(solar): add solar production forecast API and UI component

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,6 +27,7 @@ import {
   startUsageEventRetryWorker,
 } from "./lib/usageEvents.js";
 import { metricsRouter } from "./routes/metrics.js";
+import { solarRouter } from "./routes/solar.js";
 import { createRequire } from "module";
 
 const _require = createRequire(import.meta.url);
@@ -158,6 +159,7 @@ app.use("/api/allowlist", allowlistRouter);
 app.use("/api/collaborators", collaboratorRouter);
 app.use("/api/stats", statsRouter);
 app.use("/api/metrics", metricsRouter);
+app.use("/api/solar", solarRouter);
 
 // #420: GET /api/health — version, uptime, dependency status
 app.get("/api/health", async (_req, res) => {

--- a/backend/src/routes/solar.ts
+++ b/backend/src/routes/solar.ts
@@ -1,0 +1,172 @@
+import { Router, Request, Response } from "express";
+import { asyncHandler } from "../lib/asyncHandler.js";
+import { logger } from "../lib/logger.js";
+
+export const solarRouter = Router();
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** Average panel efficiency loss per year (degradation rate) */
+const DEGRADATION_RATE = 0.005;
+
+/** System losses: inverter, wiring, temperature, soiling (typical 14%) */
+const SYSTEM_LOSS = 0.86;
+
+/** Days per period */
+const PERIOD_DAYS: Record<string, number> = {
+  daily: 1,
+  weekly: 7,
+  monthly: 30,
+  yearly: 365,
+};
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface ForecastPeriod {
+  period: string;
+  days: number;
+  estimatedKwh: number;
+  estimatedRevenue: number;
+}
+
+interface ForecastResponse {
+  panelCapacityKw: number;
+  peakSunHours: number;
+  efficiency: number;
+  panelAgeYears: number;
+  effectiveDegradation: number;
+  dailyKwh: number;
+  forecast: ForecastPeriod[];
+  assumptions: {
+    systemLoss: number;
+    degradationRatePerYear: number;
+    ratePerKwh: number;
+  };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Core solar production formula:
+ *   kWh/day = capacity(kW) × peakSunHours × efficiency × systemLoss × degradationFactor
+ */
+function calcDailyKwh(
+  capacityKw: number,
+  peakSunHours: number,
+  efficiency: number,
+  panelAgeYears: number,
+): number {
+  const degradationFactor = Math.pow(1 - DEGRADATION_RATE, panelAgeYears);
+  return capacityKw * peakSunHours * efficiency * SYSTEM_LOSS * degradationFactor;
+}
+
+function parsePositiveFloat(val: unknown, name: string, max?: number): number {
+  const n = Number(val);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw Object.assign(new Error(`${name} must be a positive number`), { code: "VALIDATION_ERROR" });
+  }
+  if (max !== undefined && n > max) {
+    throw Object.assign(new Error(`${name} must be ≤ ${max}`), { code: "VALIDATION_ERROR" });
+  }
+  return n;
+}
+
+function parseNonNegativeFloat(val: unknown, name: string): number {
+  const n = Number(val);
+  if (!Number.isFinite(n) || n < 0) {
+    throw Object.assign(new Error(`${name} must be a non-negative number`), { code: "VALIDATION_ERROR" });
+  }
+  return n;
+}
+
+// ── Routes ─────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/solar/forecast
+ *
+ * Estimates solar energy production and revenue for a given panel setup.
+ *
+ * Query params:
+ *   capacityKw      — total panel capacity in kilowatts (required, e.g. 5)
+ *   peakSunHours    — average daily peak sun hours for the location (required, e.g. 5.5)
+ *   efficiency      — panel efficiency 0–1 (optional, default 0.20)
+ *   panelAgeYears   — age of panels in years for degradation calc (optional, default 0)
+ *   ratePerKwh      — local electricity rate in XLM/kWh (optional, default 0.12)
+ *
+ * Example:
+ *   GET /api/solar/forecast?capacityKw=10&peakSunHours=5.5&efficiency=0.20&ratePerKwh=0.15
+ */
+solarRouter.get(
+  "/forecast",
+  asyncHandler(async (req: Request, res: Response) => {
+    const {
+      capacityKw: rawCap,
+      peakSunHours: rawPsh,
+      efficiency: rawEff = "0.20",
+      panelAgeYears: rawAge = "0",
+      ratePerKwh: rawRate = "0.12",
+    } = req.query;
+
+    // Validate inputs
+    const capacityKw = parsePositiveFloat(rawCap, "capacityKw", 10_000);
+    const peakSunHours = parsePositiveFloat(rawPsh, "peakSunHours", 24);
+    const efficiency = parsePositiveFloat(rawEff, "efficiency", 1);
+    const panelAgeYears = parseNonNegativeFloat(rawAge, "panelAgeYears");
+    const ratePerKwh = parseNonNegativeFloat(rawRate, "ratePerKwh");
+
+    const degradationFactor = Math.pow(1 - DEGRADATION_RATE, panelAgeYears);
+    const effectiveDegradation = Number(((1 - degradationFactor) * 100).toFixed(2));
+
+    const dailyKwh = calcDailyKwh(capacityKw, peakSunHours, efficiency, panelAgeYears);
+
+    const forecast: ForecastPeriod[] = Object.entries(PERIOD_DAYS).map(
+      ([period, days]) => {
+        const estimatedKwh = Number((dailyKwh * days).toFixed(3));
+        const estimatedRevenue = Number((estimatedKwh * ratePerKwh).toFixed(4));
+        return { period, days, estimatedKwh, estimatedRevenue };
+      },
+    );
+
+    const response: ForecastResponse = {
+      panelCapacityKw: capacityKw,
+      peakSunHours,
+      efficiency,
+      panelAgeYears,
+      effectiveDegradation,
+      dailyKwh: Number(dailyKwh.toFixed(3)),
+      forecast,
+      assumptions: {
+        systemLoss: SYSTEM_LOSS,
+        degradationRatePerYear: DEGRADATION_RATE,
+        ratePerKwh,
+      },
+    };
+
+    logger.info(
+      { capacityKw, peakSunHours, efficiency, dailyKwh: response.dailyKwh },
+      "Solar forecast computed",
+    );
+
+    res.json(response);
+  }),
+);
+
+/**
+ * GET /api/solar/irradiance-zones
+ *
+ * Returns reference peak sun hour values for common climate zones.
+ * Useful for the frontend dropdown so users don't need to look this up.
+ */
+solarRouter.get("/irradiance-zones", (_req: Request, res: Response) => {
+  res.json({
+    zones: [
+      { name: "Equatorial (e.g. Kenya, Nigeria, Ghana)", peakSunHours: 6.0 },
+      { name: "Tropical wet/dry (e.g. India, Brazil)", peakSunHours: 5.5 },
+      { name: "Sub-Saharan savanna", peakSunHours: 6.5 },
+      { name: "Mediterranean (e.g. Spain, South Africa)", peakSunHours: 5.2 },
+      { name: "Temperate (e.g. Central Europe, UK)", peakSunHours: 3.5 },
+      { name: "Desert (e.g. Sahara, Arizona, Middle East)", peakSunHours: 7.5 },
+      { name: "Northern / cloudy (e.g. Scandinavia, Canada)", peakSunHours: 2.5 },
+    ],
+  });
+});

--- a/frontend/src/components/SolarForecast.tsx
+++ b/frontend/src/components/SolarForecast.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useState } from "react";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface ForecastPeriod {
+  period: string;
+  days: number;
+  estimatedKwh: number;
+  estimatedRevenue: number;
+}
+
+interface ForecastResult {
+  panelCapacityKw: number;
+  peakSunHours: number;
+  efficiency: number;
+  panelAgeYears: number;
+  effectiveDegradation: number;
+  dailyKwh: number;
+  forecast: ForecastPeriod[];
+  assumptions: {
+    systemLoss: number;
+    degradationRatePerYear: number;
+    ratePerKwh: number;
+  };
+}
+
+interface IrradianceZone {
+  name: string;
+  peakSunHours: number;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+const PERIOD_ICONS: Record<string, string> = {
+  daily: "☀️",
+  weekly: "📅",
+  monthly: "🗓️",
+  yearly: "📊",
+};
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+function ForecastCard({ period }: { period: ForecastPeriod }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-solar-dark p-4 flex flex-col gap-1">
+      <div className="flex items-center gap-1.5 text-xs text-gray-400 uppercase tracking-wide font-medium">
+        <span aria-hidden="true">{PERIOD_ICONS[period.period] ?? "⚡"}</span>
+        {period.period}
+      </div>
+      <p className="text-xl font-bold text-solar-yellow">
+        {period.estimatedKwh.toLocaleString()} <span className="text-sm font-normal text-gray-400">kWh</span>
+      </p>
+      <p className="text-sm text-gray-400">
+        ≈ <span className="text-white font-semibold">{period.estimatedRevenue.toFixed(2)}</span> XLM
+      </p>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export default function SolarForecast() {
+  // Form state
+  const [capacityKw, setCapacityKw] = useState("5");
+  const [peakSunHours, setPeakSunHours] = useState("5.5");
+  const [efficiency, setEfficiency] = useState("0.20");
+  const [panelAgeYears, setPanelAgeYears] = useState("0");
+  const [ratePerKwh, setRatePerKwh] = useState("0.12");
+
+  // Async state
+  const [result, setResult] = useState<ForecastResult | null>(null);
+  const [zones, setZones] = useState<IrradianceZone[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [zonesLoaded, setZonesLoaded] = useState(false);
+
+  // Load irradiance zones lazily on first focus of peakSunHours field
+  async function loadZones() {
+    if (zonesLoaded) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/solar/irradiance-zones`);
+      if (res.ok) {
+        const data = await res.json();
+        setZones(data.zones ?? []);
+      }
+    } catch {
+      // non-critical, silently ignore
+    } finally {
+      setZonesLoaded(true);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const params = new URLSearchParams({
+        capacityKw,
+        peakSunHours,
+        efficiency,
+        panelAgeYears,
+        ratePerKwh,
+      });
+
+      const res = await fetch(`${API_BASE}/api/solar/forecast?${params}`);
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? `Request failed (${res.status})`);
+      }
+
+      setResult(data as ForecastResult);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section aria-labelledby="solar-forecast-title" className="w-full max-w-2xl mx-auto space-y-6">
+
+      {/* Header */}
+      <div>
+        <h2 id="solar-forecast-title" className="text-xl font-bold text-white flex items-center gap-2">
+          <span aria-hidden="true">🌞</span> Solar Production Forecast
+        </h2>
+        <p className="mt-1 text-sm text-gray-400">
+          Estimate daily, weekly, monthly and yearly kWh output and XLM revenue for your solar installation.
+        </p>
+      </div>
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-2xl border border-white/10 bg-solar-accent p-5 space-y-4"
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+
+          {/* Panel capacity */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="capacityKw" className="text-xs font-medium text-gray-300">
+              Panel capacity (kW) <span className="text-red-400" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="capacityKw"
+              type="number"
+              min="0.1"
+              step="0.1"
+              required
+              value={capacityKw}
+              onChange={(e) => setCapacityKw(e.target.value)}
+              className="rounded-lg border border-white/10 bg-solar-dark px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+              placeholder="e.g. 5"
+            />
+          </div>
+
+          {/* Peak sun hours with zone picker */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="peakSunHours" className="text-xs font-medium text-gray-300">
+              Peak sun hours / day <span className="text-red-400" aria-hidden="true">*</span>
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="peakSunHours"
+                type="number"
+                min="0.1"
+                max="24"
+                step="0.1"
+                required
+                value={peakSunHours}
+                onChange={(e) => setPeakSunHours(e.target.value)}
+                onFocus={loadZones}
+                className="flex-1 rounded-lg border border-white/10 bg-solar-dark px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+                placeholder="e.g. 5.5"
+              />
+              {zones.length > 0 && (
+                <select
+                  aria-label="Pick from climate zone"
+                  onChange={(e) => e.target.value && setPeakSunHours(e.target.value)}
+                  defaultValue=""
+                  className="rounded-lg border border-white/10 bg-solar-dark px-2 py-2 text-xs text-gray-400 focus:border-solar-yellow focus:outline-none transition"
+                >
+                  <option value="" disabled>Zone</option>
+                  {zones.map((z) => (
+                    <option key={z.name} value={String(z.peakSunHours)}>
+                      {z.peakSunHours}h — {z.name.split("(")[0].trim()}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          </div>
+
+          {/* Efficiency */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="efficiency" className="text-xs font-medium text-gray-300">
+              Panel efficiency (0–1)
+            </label>
+            <input
+              id="efficiency"
+              type="number"
+              min="0.01"
+              max="1"
+              step="0.01"
+              value={efficiency}
+              onChange={(e) => setEfficiency(e.target.value)}
+              className="rounded-lg border border-white/10 bg-solar-dark px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+              placeholder="0.20"
+            />
+            <p className="text-xs text-gray-600">Typical mono-PERC panels: 0.20–0.23</p>
+          </div>
+
+          {/* Panel age */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="panelAgeYears" className="text-xs font-medium text-gray-300">
+              Panel age (years)
+            </label>
+            <input
+              id="panelAgeYears"
+              type="number"
+              min="0"
+              max="40"
+              step="1"
+              value={panelAgeYears}
+              onChange={(e) => setPanelAgeYears(e.target.value)}
+              className="rounded-lg border border-white/10 bg-solar-dark px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+              placeholder="0"
+            />
+          </div>
+
+          {/* Rate per kWh */}
+          <div className="flex flex-col gap-1.5 sm:col-span-2">
+            <label htmlFor="ratePerKwh" className="text-xs font-medium text-gray-300">
+              Revenue rate (XLM / kWh)
+            </label>
+            <input
+              id="ratePerKwh"
+              type="number"
+              min="0"
+              step="0.001"
+              value={ratePerKwh}
+              onChange={(e) => setRatePerKwh(e.target.value)}
+              className="w-full sm:w-1/2 rounded-lg border border-white/10 bg-solar-dark px-3 py-2 text-sm text-white placeholder-gray-600 focus:border-solar-yellow focus:outline-none transition"
+              placeholder="0.12"
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded-lg bg-solar-yellow py-3 text-sm font-semibold text-solar-dark transition hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          {loading ? (
+            <>
+              <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+              </svg>
+              Calculating…
+            </>
+          ) : (
+            "Calculate forecast"
+          )}
+        </button>
+      </form>
+
+      {/* Error */}
+      {error && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-500/30 bg-red-900/20 px-4 py-3 text-sm text-red-300"
+        >
+          ✕ {error}
+        </div>
+      )}
+
+      {/* Results */}
+      {result && (
+        <div className="space-y-4" aria-live="polite">
+
+          {/* Summary bar */}
+          <div className="rounded-xl border border-solar-yellow/30 bg-solar-yellow/5 px-5 py-4 flex flex-wrap gap-6">
+            <div>
+              <p className="text-xs text-gray-400">Daily output</p>
+              <p className="text-2xl font-bold text-solar-yellow">
+                {result.dailyKwh} <span className="text-sm font-normal text-gray-400">kWh</span>
+              </p>
+            </div>
+            {result.effectiveDegradation > 0 && (
+              <div>
+                <p className="text-xs text-gray-400">Panel degradation</p>
+                <p className="text-lg font-semibold text-orange-400">
+                  −{result.effectiveDegradation}%
+                </p>
+              </div>
+            )}
+            <div>
+              <p className="text-xs text-gray-400">System loss applied</p>
+              <p className="text-lg font-semibold text-white">
+                {((1 - result.assumptions.systemLoss) * 100).toFixed(0)}%
+              </p>
+            </div>
+          </div>
+
+          {/* Period cards */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {result.forecast.map((p) => (
+              <ForecastCard key={p.period} period={p} />
+            ))}
+          </div>
+
+          {/* Assumptions */}
+          <details className="rounded-xl border border-white/10 bg-solar-dark text-xs text-gray-500">
+            <summary className="cursor-pointer px-4 py-3 text-gray-400 hover:text-white transition select-none">
+              View assumptions
+            </summary>
+            <ul className="px-4 pb-4 pt-1 space-y-1">
+              <li>Capacity: <span className="text-gray-300">{result.panelCapacityKw} kW</span></li>
+              <li>Peak sun hours: <span className="text-gray-300">{result.peakSunHours} h/day</span></li>
+              <li>Panel efficiency: <span className="text-gray-300">{(result.efficiency * 100).toFixed(0)}%</span></li>
+              <li>System losses (inverter, wiring, soiling): <span className="text-gray-300">{((1 - result.assumptions.systemLoss) * 100).toFixed(0)}%</span></li>
+              <li>Annual degradation rate: <span className="text-gray-300">{(result.assumptions.degradationRatePerYear * 100).toFixed(1)}%/yr</span></li>
+              <li>Revenue rate: <span className="text-gray-300">{result.assumptions.ratePerKwh} XLM/kWh</span></li>
+            </ul>
+          </details>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary\n\nAdds solar energy production forecasting to the SolarGrid platform.\n\n## Changes\n\n**Backend**\n- GET /api/solar/forecast — estimates kWh and XLM revenue for daily/weekly/monthly/yearly periods\n- Accounts for panel capacity, peak sun hours, efficiency, age degradation and system losses\n- GET /api/solar/irradiance-zones — reference peak sun hours by climate zone\n- Full input validation with descriptive errors\n\n**Frontend**\n- SolarForecast React component with form inputs, climate zone picker, result cards and assumptions panel\n- Matches project dark solar theme (Tailwind, no external UI libs)

Closes #397 