### PR TITLE
feat(frontend): add WalletConnectButton component with Freighter connect/disconnect state

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useWalletStore } from "@/store/walletStore";
+import { WalletConnectButton } from "@/components/WalletConnectButton";
 
 const NAV_LINKS = [
   { href: "/dashboard/user", label: "My Meter" },
@@ -12,7 +13,7 @@ const NAV_LINKS = [
 ];
 
 export default function Navbar() {
-  const { address, connect, disconnect, connectError, clearConnectError } = useWalletStore();
+  const { connectError, clearConnectError } = useWalletStore();
   const [menuOpen, setMenuOpen] = useState(false);
   const [theme, setTheme] = useState("dark");
 
@@ -22,14 +23,12 @@ export default function Navbar() {
     document.documentElement.setAttribute("data-theme", savedTheme);
   }, []);
 
-  const toggleTheme = () => {
+  function toggleTheme() {
     const next = theme === "dark" ? "light" : "dark";
     setTheme(next);
     localStorage.setItem("theme", next);
     document.documentElement.setAttribute("data-theme", next);
-  };
-
-  const short = address ? `${address.slice(0, 4)}â€¦${address.slice(-4)}` : null;
+  }
 
   function closeMenu() {
     setMenuOpen(false);
@@ -39,8 +38,8 @@ export default function Navbar() {
     <nav className="bg-solar-accent border-b border-white/10 relative z-50">
       {/* Top bar */}
       <div className="flex items-center justify-between px-4 py-3 sm:px-6">
-        <Link to="/" className="text-xl font-bold text-solar-yellow" onClick={closeMenu}>
-          â˜€ï¸ SolarGrid
+        <Link href="/" className="text-xl font-bold text-solar-yellow" onClick={closeMenu}>
+          ☀️ SolarGrid
         </Link>
 
         {/* Desktop links */}
@@ -48,42 +47,24 @@ export default function Navbar() {
           {NAV_LINKS.map((l) => (
             <Link
               key={l.href}
-              to={l.href}
+              href={l.href}
               className="text-sm text-gray-300 hover:text-white transition"
             >
               {l.label}
             </Link>
           ))}
-          <button onClick={toggleTheme} className="text-xl" title="Toggle Theme">
+          <button onClick={toggleTheme} className="text-xl" title="Toggle Theme" aria-label="Toggle theme">
             {theme === "dark" ? "🌙" : "☀️"}
           </button>
-          <WalletButton address={short} connect={connect} disconnect={disconnect} />
-          {address && (
-            <button
-              onClick={disconnect}
-              className="text-xs text-gray-400 hover:text-white transition ml-2"
-              title="Disconnect wallet"
-            >
-              Disconnect
-            </button>
-          )}
+          <WalletConnectButton />
         </div>
 
         {/* Mobile: wallet button + hamburger */}
         <div className="flex items-center gap-2 sm:hidden">
-          <button onClick={toggleTheme} className="text-xl" title="Toggle Theme">
+          <button onClick={toggleTheme} className="text-xl" title="Toggle Theme" aria-label="Toggle theme">
             {theme === "dark" ? "🌙" : "☀️"}
           </button>
-          <WalletButton address={short} connect={connect} disconnect={disconnect} compact />
-          {address && (
-            <button
-              onClick={disconnect}
-              className="text-xs text-gray-400 hover:text-white transition"
-              title="Disconnect wallet"
-            >
-              ✕
-            </button>
-          )}
+          <WalletConnectButton compact />
           <button
             onClick={() => setMenuOpen((o) => !o)}
             aria-label={menuOpen ? "Close menu" : "Open menu"}
@@ -91,13 +72,11 @@ export default function Navbar() {
             className="rounded-lg border border-white/10 p-2 text-gray-300 hover:border-solar-yellow hover:text-solar-yellow transition"
           >
             {menuOpen ? (
-              /* X icon */
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" />
               </svg>
             ) : (
-              /* Hamburger icon */
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path d="M3 5h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2z" />
               </svg>
             )}
@@ -107,10 +86,13 @@ export default function Navbar() {
 
       {/* Wallet connect error banner */}
       {connectError && (
-        <div className="flex items-center justify-between gap-3 border-t border-red-500/30 bg-red-900/20 px-4 py-2.5 text-sm text-red-400">
+        <div
+          role="alert"
+          className="flex items-center justify-between gap-3 border-t border-red-500/30 bg-red-900/20 px-4 py-2.5 text-sm text-red-400"
+        >
           <span>
             {connectError}{" "}
-            {connectError.includes("not installed") && (
+            {connectError.toLowerCase().includes("not installed") && (
               <a
                 href="https://freighter.app"
                 target="_blank"
@@ -137,7 +119,7 @@ export default function Navbar() {
           {NAV_LINKS.map((l) => (
             <Link
               key={l.href}
-              to={l.href}
+              href={l.href}
               onClick={closeMenu}
               className="block rounded-lg px-3 py-3 text-sm text-gray-300 hover:bg-white/5 hover:text-white transition"
             >
@@ -149,49 +131,3 @@ export default function Navbar() {
     </nav>
   );
 }
-
-function WalletButton({
-  address,
-  connect,
-  disconnect,
-  compact = false,
-}: {
-  address: string | null;
-  connect: () => void;
-  disconnect: () => void;
-  compact?: boolean;
-}) {
-  const { address: fullAddress } = useWalletStore();
-  const [copied, setCopied] = useState(false);
-
-  const copyAddress = async () => {
-    if (!fullAddress) return;
-    await navigator.clipboard.writeText(fullAddress);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  if (address) {
-    return (
-      <button
-        onClick={copyAddress}
-        className="rounded-lg border border-solar-yellow px-3 py-1.5 text-xs font-medium text-solar-yellow hover:bg-solar-yellow hover:text-solar-dark transition"
-        title="Copy full address"
-        aria-label="Copy wallet address"
-      >
-        {copied ? 'Copied!' : address}
-      </button>
-    );
-  }
-  return (
-    <button
-      onClick={connect}
-      className={`rounded-lg bg-solar-yellow font-semibold text-solar-dark hover:opacity-90 transition ${
-        compact ? "px-3 py-1.5 text-xs" : "px-4 py-1.5 text-sm"
-      }`}
-    >
-      {compact ? "Connect" : "Connect Wallet"}
-    </button>
-  );
-}
-

--- a/frontend/src/components/WalletConnectButton.tsx
+++ b/frontend/src/components/WalletConnectButton.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { useWalletStore } from "@/store/walletStore";
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+/** Tooltip shown when Freighter is not detected */
+function FreighterTooltip({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <div
+      role="tooltip"
+      className="absolute bottom-full left-1/2 mb-2 w-56 -translate-x-1/2 rounded-lg border border-yellow-500/30 bg-yellow-900/90 px-3 py-2 text-xs text-yellow-200 shadow-xl backdrop-blur-sm z-50"
+    >
+      <p className="font-semibold mb-1">Freighter not detected</p>
+      <a
+        href="https://freighter.app"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2 hover:text-white transition"
+        onClick={(e) => e.stopPropagation()}
+      >
+        Install Freighter ↗
+      </a>
+      {/* Arrow */}
+      <div
+        aria-hidden="true"
+        className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-yellow-900/90"
+      />
+    </div>
+  );
+}
+
+/** Animated spinner used during the connecting handshake */
+function Spinner() {
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12" cy="12" r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}
+
+// ── Props ──────────────────────────────────────────────────────────────────
+
+interface WalletConnectButtonProps {
+  /** Renders a smaller pill-shaped variant for mobile/compact layouts */
+  compact?: boolean;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+/**
+ * WalletConnectButton
+ *
+ * Centralised connect/disconnect control for the Freighter wallet.
+ * - Shows truncated address + copy + disconnect when connected
+ * - Shows "Connect Wallet" with spinner while handshake is in progress
+ * - Shows a tooltip with install link when Freighter is not detected
+ * - Surfaces connectError from the wallet store inline
+ *
+ * Closes #398
+ */
+export function WalletConnectButton({ compact = false }: WalletConnectButtonProps) {
+  const { address, connect, disconnect, isConnecting, connectError, clearConnectError } =
+    useWalletStore();
+
+  const [copied, setCopied] = useState(false);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+
+  const isNotInstalled =
+    !!connectError &&
+    (connectError.toLowerCase().includes("not installed") ||
+      connectError.toLowerCase().includes("undefined"));
+
+  const truncated = address
+    ? `${address.slice(0, 4)}…${address.slice(-4)}`
+    : null;
+
+  async function handleCopy() {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable — silent fail
+    }
+  }
+
+  function handleConnectClick() {
+    if (isConnecting) return;
+    clearConnectError();
+    connect().then(() => {
+      setTooltipVisible(false);
+    });
+  }
+
+  // ── Connected state ──────────────────────────────────────────────────────
+  if (address) {
+    return (
+      <div className="flex items-center gap-1.5">
+        {/* Address pill — click to copy */}
+        <button
+          type="button"
+          onClick={handleCopy}
+          title="Click to copy full address"
+          aria-label={`Wallet address ${address}. Click to copy.`}
+          className={[
+            "rounded-lg border border-solar-yellow font-mono font-medium text-solar-yellow",
+            "hover:bg-solar-yellow hover:text-solar-dark transition",
+            compact ? "px-2.5 py-1 text-xs" : "px-3 py-1.5 text-xs",
+          ].join(" ")}
+        >
+          {copied ? "✓ Copied" : truncated}
+        </button>
+
+        {/* Disconnect button */}
+        <button
+          type="button"
+          onClick={disconnect}
+          title="Disconnect wallet"
+          aria-label="Disconnect wallet"
+          className={[
+            "rounded-lg border border-white/10 text-gray-400",
+            "hover:border-red-500/50 hover:text-red-400 transition",
+            compact ? "px-2 py-1 text-xs" : "px-2.5 py-1.5 text-xs",
+          ].join(" ")}
+        >
+          {compact ? "✕" : "Disconnect"}
+        </button>
+      </div>
+    );
+  }
+
+  // ── Disconnected / connecting state ──────────────────────────────────────
+  return (
+    <div className="relative flex flex-col items-center gap-1">
+      <button
+        type="button"
+        onClick={handleConnectClick}
+        disabled={isConnecting}
+        onMouseEnter={() => isNotInstalled && setTooltipVisible(true)}
+        onMouseLeave={() => setTooltipVisible(false)}
+        onFocus={() => isNotInstalled && setTooltipVisible(true)}
+        onBlur={() => setTooltipVisible(false)}
+        aria-busy={isConnecting}
+        aria-describedby={isNotInstalled ? "freighter-tooltip" : undefined}
+        className={[
+          "rounded-lg bg-solar-yellow font-semibold text-solar-dark",
+          "hover:brightness-110 transition",
+          "disabled:opacity-60 disabled:cursor-not-allowed",
+          "flex items-center gap-1.5",
+          compact ? "px-3 py-1.5 text-xs" : "px-4 py-1.5 text-sm",
+        ].join(" ")}
+      >
+        {isConnecting && <Spinner />}
+        {isConnecting ? "Connecting…" : compact ? "Connect" : "Connect Wallet"}
+      </button>
+
+      {/* Freighter not-installed tooltip */}
+      <FreighterTooltip visible={tooltipVisible} />
+
+      {/* Inline error (non-tooltip fallback for touch devices) */}
+      {connectError && !isNotInstalled && (
+        <p className="absolute top-full mt-1 w-max max-w-xs text-xs text-red-400 text-center">
+          {connectError}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default WalletConnectButton;

--- a/frontend/src/store/walletStore.ts
+++ b/frontend/src/store/walletStore.ts
@@ -12,6 +12,7 @@ interface WalletState {
   address: string | null;
   kit: StellarWalletsKit | null;
   connectError: string | null;
+  isConnecting: boolean;
   connect: () => Promise<void>;
   disconnect: () => void;
   clearConnectError: () => void;
@@ -33,9 +34,10 @@ export const useWalletStore = create<WalletState>((set, get) => ({
   address: null,
   kit: null,
   connectError: null,
+  isConnecting: false,
 
   connect: async () => {
-    set({ connectError: null });
+    set({ connectError: null, isConnecting: true });
     try {
       const kit = buildKit();
       await kit.openModal({
@@ -57,6 +59,8 @@ export const useWalletStore = create<WalletState>((set, get) => ({
           ? "Selected wallet is not installed."
           : msg,
       });
+    } finally {
+      set({ isConnecting: false });
     }
   },
 


### PR DESCRIPTION
## Summary\n\nCloses #398\n\nCentralises wallet connection logic into a dedicated WalletConnectButton component.\n\n## Changes\n\n**walletStore.ts**\n- Add isConnecting boolean with proper finally cleanup so spinner never gets stuck\n\n**WalletConnectButton.tsx** (new)\n- Connected state: truncated address pill (click to copy) + Disconnect button\n- Disconnected state: Connect Wallet button with animated spinner during handshake\n- Freighter-not-installed: tooltip with Install Freighter link on hover/focus\n- compact prop for mobile/navbar use\n\n**Navbar.tsx**\n- Replace inline WalletButton with WalletConnectButton (compact on mobile, full on desktop)\n- Remove duplicate disconnect button\n- Fix Link to/href props for Next.js\n\n## Definition of Done\n- [x] Renders connect/disconnect based on wallet state\n- [x] Truncated address shown when connected\n- [x] isConnecting spinner during Freighter handshake\n- [x] Placed in Navbar\n- [x] Handles Freighter-not-installed gracefully with tooltip