### PR TITLE
fix(frontend): guard UsageChart against null/undefined/empty data

### DIFF
--- a/frontend/src/__tests__/UsageChart.test.tsx
+++ b/frontend/src/__tests__/UsageChart.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import UsageChart, { UsageDataPoint } from "@/components/UsageChart";
+
+// recharts uses ResizeObserver internally — polyfill for jsdom
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const SAMPLE_DATA: UsageDataPoint[] = [
+  { date: "2024-01-01", units: 3.2, cost: 0.48 },
+  { date: "2024-01-02", units: 4.1, cost: 0.62 },
+  { date: "2024-01-03", units: 2.8, cost: 0.42 },
+];
+
+describe("UsageChart", () => {
+  // ── Empty / null / undefined guards ──────────────────────────────────────
+
+  it("renders empty state placeholder when data is an empty array", () => {
+    render(<UsageChart data={[]} />);
+    expect(screen.getByRole("status", { name: /no usage data/i })).toBeInTheDocument();
+    expect(screen.getByText(/no usage data yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/first recorded unit/i)).toBeInTheDocument();
+  });
+
+  it("renders empty state placeholder when data is null (does not throw)", () => {
+    // TypeScript allows null via the optional prop — runtime guard must hold
+    expect(() => render(<UsageChart data={null as any} />)).not.toThrow();
+    expect(screen.getByRole("status", { name: /no usage data/i })).toBeInTheDocument();
+  });
+
+  it("renders empty state placeholder when data is undefined (does not throw)", () => {
+    expect(() => render(<UsageChart data={undefined} />)).not.toThrow();
+    expect(screen.getByRole("status", { name: /no usage data/i })).toBeInTheDocument();
+  });
+
+  it("renders empty state placeholder when data prop is omitted entirely", () => {
+    expect(() => render(<UsageChart />)).not.toThrow();
+    expect(screen.getByText(/no usage data yet/i)).toBeInTheDocument();
+  });
+
+  // ── Layout consistency ────────────────────────────────────────────────────
+
+  it("empty state container has h-48 class to preserve card height", () => {
+    render(<UsageChart data={[]} />);
+    const placeholder = screen.getByRole("status");
+    expect(placeholder.className).toContain("h-48");
+  });
+
+  // ── Loading state ─────────────────────────────────────────────────────────
+
+  it("renders skeleton when loading=true, even with empty data", () => {
+    const { container } = render(<UsageChart data={[]} loading={true} />);
+    // Skeleton uses animate-pulse; empty state must NOT appear while loading
+    expect(screen.queryByRole("status", { name: /no usage data/i })).not.toBeInTheDocument();
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  // ── Data rendering ────────────────────────────────────────────────────────
+
+  it("does not show empty state when data has entries", () => {
+    render(<UsageChart data={SAMPLE_DATA} />);
+    expect(screen.queryByText(/no usage data yet/i)).not.toBeInTheDocument();
+  });
+
+  it("shows meterId in header when provided", () => {
+    render(<UsageChart data={SAMPLE_DATA} meterId="METER_001" />);
+    expect(screen.getByText("METER_001")).toBeInTheDocument();
+  });
+
+  it("shows meter header without meterId", () => {
+    render(<UsageChart data={SAMPLE_DATA} />);
+    expect(screen.getByText("Energy Usage")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/UsageChart.tsx
+++ b/frontend/src/components/UsageChart.tsx
@@ -20,7 +20,8 @@ export interface UsageDataPoint {
 }
 
 interface UsageChartProps {
-  data: UsageDataPoint[];
+  /** Usage data points. Null/undefined treated as empty — no crash. */
+  data?: UsageDataPoint[] | null;
   /** Pass true while the parent is still fetching meter data */
   loading?: boolean;
   meterId?: string;
@@ -87,10 +88,12 @@ function CustomTooltip({
 import styles from './UsageChart.module.css';
 
 export default function UsageChart({
-  data,
+  data: rawData,
   loading = false,
   meterId,
 }: UsageChartProps) {
+  // Normalise: null/undefined → empty array so no downstream code can throw
+  const data: UsageDataPoint[] = Array.isArray(rawData) ? rawData : [];
   const isEmpty = !loading && data.length === 0;
 
   return (
@@ -115,8 +118,16 @@ export default function UsageChart({
         {loading ? (
           <ChartSkeleton />
         ) : isEmpty ? (
-          <div className="flex h-48 items-center justify-center text-sm text-gray-500">
-            No usage data available yet.
+          <div
+            role="status"
+            aria-label="No usage data"
+            className="flex h-48 flex-col items-center justify-center gap-2 text-center"
+          >
+            <span className="text-2xl" aria-hidden="true">📊</span>
+            <p className="text-sm text-gray-400 font-medium">No usage data yet</p>
+            <p className="text-xs text-gray-600 max-w-xs">
+              Data will appear here after your first recorded unit.
+            </p>
           </div>
         ) : (
           <ResponsiveContainer width="100%" height={192}>


### PR DESCRIPTION
## Summary\n\nFixes #399\n\nUsageChart crashed when recharts received an empty dataset for Y-axis domain calculation. This adds a defensive normalisation layer and a proper empty state UI.\n\n## Root Cause\n\nThe component called data.length and data.some() directly without guarding against null/undefined props. Recharts also throws internally when computing axis domains from an empty array.\n\n## Changes\n\n**UsageChart.tsx**\n- data prop is now UsageDataPoint[] | null | undefined (optional)\n- Normalise rawData to [] via Array.isArray() before any access — null/undefined can never reach recharts\n- Improved empty state: role=status, descriptive copy, h-48 preserves card height so layout does not shift\n\n**UsageChart.test.tsx** (new — 8 test cases)\n- Empty array renders placeholder, not a throw\n- null prop does not throw\n- undefined prop does not throw\n- Omitted prop does not throw\n- Empty state container has h-48 class\n- loading=true shows skeleton, not empty state\n- Data present does not show empty state\n- meterId renders in header\n\n## Definition of Done\n- [x] Empty array renders placeholder instead of crashing\n- [x] Null/undefined data prop handled safely\n- [x] Placeholder styled with h-48 to match chart height\n- [x] Unit tests with empty data confirm no throw

Closes #399 