### PR TITLE
feat: Add admin transfer meter ownership endpoint

### DIFF
--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -436,6 +436,45 @@ export function createMeterRouter(stellar: StellarService) {
     }),
   );
 
+  /** POST /api/meters/:id/transfer — admin transfers meter ownership to a new owner */
+  meterRouter.post(
+    "/:id/transfer",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const meterId = req.params.id;
+      const { new_owner } = req.body;
+
+      // Validate new_owner is provided
+      if (!new_owner) {
+        return res.status(400).json({ error: "new_owner is required", code: "VALIDATION_ERROR" });
+      }
+
+      // Validate new_owner is a valid Stellar address
+      try {
+        StellarSdk.StrKey.decodeEd25519PublicKey(new_owner);
+      } catch {
+        return res.status(400).json({ error: "Invalid Stellar address", code: "VALIDATION_ERROR" });
+      }
+
+      // Check if meter exists
+      try {
+        await stellar.query("get_meter", [
+          StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        ]);
+      } catch {
+        return res.status(404).json({ error: "Meter not found", code: "NOT_FOUND" });
+      }
+
+      // Invoke transfer_meter_ownership contract function
+      const hash = await stellar.invoke("transfer_meter_ownership", [
+        StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
+        StellarSdk.nativeToScVal(new_owner, { type: "address" }),
+      ]);
+
+      res.json({ hash, meter_id: meterId, new_owner });
+    }),
+  );
+
   return meterRouter;
 }
   /** DELETE /api/meters/:id — admin deregisters a meter */


### PR DESCRIPTION
Closes #438

---

This closes issue #438 

## Summary
Add a new admin-only endpoint that invokes the transfer_meter_ownership contract function so ownership can be changed without requiring a dual-signature flow from the API side.

## Changes
- Added POST /api/meters/:id/transfer endpoint
- Validates new_owner is a valid Stellar address
- Protected by requireAdminKey middleware
- Returns { hash, meter_id, new_owner } on success
- Returns 404 if meter does not exist

## Acceptance Criteria
- [x] POST /api/meters/:id/transfer accepts { new_owner: string } in the request body
- [x] Validates new_owner is a valid Stellar address
- [x] Protected by requireAdminKey middleware
- [x] Returns { hash, meter_id, new_owner } on success
- [x] Returns 404 if meter does not exist
- [x] Added before the catch-all /:id handler
