### PR TITLE
feat: Add webhook retry queue with exponential backoff

### DIFF
--- a/backend/src/iot/bridge.ts
+++ b/backend/src/iot/bridge.ts
@@ -11,7 +11,7 @@
 import mqtt from "mqtt";
 import { logger } from "../lib/logger.js";
 import { persistAndSubmitUsageEvent, insertSubmittedUsageEvents, getKV, setKV } from "../lib/usageEvents.js";
-import { getWebhookUrls } from "../lib/webhookRegistry.js";
+import { getWebhookUrls, fireWebhook } from "../lib/webhookRegistry.js";
 import { UsageUpdateSchema } from "../lib/validation.js";
 import {
   adminInvoke,
@@ -66,19 +66,16 @@ async function checkAndNotifyLowBalance(meterId: string) {
         threshold: LOW_BALANCE_THRESHOLD,
         timestamp: new Date().toISOString(),
       });
+
+      // Fire webhooks with automatic retry
       await Promise.all(
-        [...urls].map((url) =>
-          fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body,
-          }).catch((err) => logger.error("Low balance webhook failed", { url, meterId, err })),
-        ),
+        [...urls].map((url) => fireWebhook(url, body)),
       );
+
       logger.info("Low balance webhook fired", { meterId, balance });
     }
   } catch (err) {
-    logger.error("Low balance webhook failed", { meterId, err });
+    logger.error("Low balance webhook check failed", { meterId, err });
   }
 }
 

--- a/backend/src/lib/webhookRegistry.ts
+++ b/backend/src/lib/webhookRegistry.ts
@@ -1,4 +1,18 @@
+import { logger } from "./logger.js";
+
 const webhookUrls = new Set<string>();
+
+interface WebhookQueueItem {
+  url: string;
+  payload: string;
+  attempt: number;
+  nextRetryAt: number;
+}
+
+const MAX_RETRIES = 5;
+const retryQueue: WebhookQueueItem[] = [];
+let retryTimerHandle: NodeJS.Timeout | null = null;
+let isShuttingDown = false;
 
 export function registerWebhook(url: string): void {
   webhookUrls.add(url);
@@ -7,3 +21,164 @@ export function registerWebhook(url: string): void {
 export function getWebhookUrls(): ReadonlySet<string> {
   return webhookUrls;
 }
+
+/**
+ * Fire a webhook with automatic retry on failure.
+ * Implements exponential backoff: 1s, 2s, 4s, 8s, 16s (max 5 retries)
+ */
+export async function fireWebhook(url: string, payload: string): Promise<void> {
+  return fireWebhookInternal(url, payload, 0);
+}
+
+async function fireWebhookInternal(
+  url: string,
+  payload: string,
+  attempt: number,
+): Promise<void> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      signal: AbortSignal.timeout(10_000), // 10 second timeout
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    // Success - log if this was a retry
+    if (attempt > 0) {
+      logger.info("Webhook delivery succeeded after retry", { url, attempt });
+    }
+  } catch (err: any) {
+    // Log the failure
+    logger.warn("Webhook delivery failed", {
+      url,
+      attempt: attempt + 1,
+      maxRetries: MAX_RETRIES,
+      error: err.message,
+    });
+
+    // Retry if we haven't exceeded max attempts
+    if (attempt < MAX_RETRIES) {
+      const backoffMs = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s, 8s, 16s
+      const nextRetryAt = Date.now() + backoffMs;
+
+      retryQueue.push({
+        url,
+        payload,
+        attempt: attempt + 1,
+        nextRetryAt,
+      });
+
+      scheduleRetryProcessor();
+    } else {
+      logger.error("Webhook delivery failed permanently after max retries", {
+        url,
+        attempts: MAX_RETRIES + 1,
+      });
+    }
+  }
+}
+
+/**
+ * Process retry queue - fires webhooks that are ready to retry
+ */
+function processRetryQueue(): void {
+  if (retryQueue.length === 0) {
+    retryTimerHandle = null;
+    return;
+  }
+
+  const now = Date.now();
+  const readyItems: WebhookQueueItem[] = [];
+  const remainingItems: WebhookQueueItem[] = [];
+
+  // Partition queue into ready and not-ready items
+  for (const item of retryQueue) {
+    if (item.nextRetryAt <= now) {
+      readyItems.push(item);
+    } else {
+      remainingItems.push(item);
+    }
+  }
+
+  // Update queue
+  retryQueue.length = 0;
+  retryQueue.push(...remainingItems);
+
+  // Fire ready webhooks
+  for (const item of readyItems) {
+    fireWebhookInternal(item.url, item.payload, item.attempt).catch(() => {
+      // Errors are handled inside fireWebhookInternal
+    });
+  }
+
+  // Schedule next processing run
+  scheduleRetryProcessor();
+}
+
+/**
+ * Schedule the next retry processor run
+ */
+function scheduleRetryProcessor(): void {
+  if (retryTimerHandle) return; // Already scheduled
+  if (retryQueue.length === 0) return; // Nothing to process
+
+  // Find the earliest retry time
+  const nextRetry = Math.min(...retryQueue.map((item) => item.nextRetryAt));
+  const delay = Math.max(0, nextRetry - Date.now());
+
+  retryTimerHandle = setTimeout(() => {
+    retryTimerHandle = null;
+    processRetryQueue();
+  }, delay);
+}
+
+/**
+ * Drain the retry queue on shutdown.
+ * Attempts to deliver all pending webhooks immediately.
+ */
+export async function drainWebhookQueue(): Promise<void> {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  if (retryTimerHandle) {
+    clearTimeout(retryTimerHandle);
+    retryTimerHandle = null;
+  }
+
+  if (retryQueue.length === 0) {
+    logger.info("Webhook queue empty, nothing to drain");
+    return;
+  }
+
+  logger.info("Draining webhook retry queue", { pending: retryQueue.length });
+
+  // Fire all pending webhooks immediately (don't retry on failure during shutdown)
+  const promises = retryQueue.map((item) =>
+    fetch(item.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: item.payload,
+      signal: AbortSignal.timeout(5_000), // Shorter timeout during shutdown
+    }).catch((err) => {
+      logger.warn("Failed to deliver webhook during shutdown drain", {
+        url: item.url,
+        attempt: item.attempt,
+        error: err.message,
+      });
+    }),
+  );
+
+  await Promise.allSettled(promises);
+  retryQueue.length = 0;
+  logger.info("Webhook queue drained");
+}
+
+// Register SIGTERM handler to drain queue on shutdown
+process.on("SIGTERM", async () => {
+  logger.info("SIGTERM received, draining webhook queue");
+  await drainWebhookQueue();
+});


### PR DESCRIPTION
Closes #440

---

## Summary
Adds an in-memory retry queue with exponential backoff for webhook delivery failures. This ensures that transient provider outages don't cause missed low-balance alerts.

## Changes
- Implemented retry queue in webhookRegistry.ts with exponential backoff (1s, 2s, 4s, 8s, 16s)
- Maximum 5 retry attempts before permanent failure
- Failed attempts logged at WARN level with webhook URL and attempt count
- Added drainWebhookQueue() function for graceful shutdown
- SIGTERM handler ensures queue is drained before process exits
- Updated bridge.ts to use new fireWebhook() function
- Added 10-second timeout for webhook requests
- 5-second timeout during shutdown drain

## Technical Details
- **Exponential backoff**: 2^attempt * 1000ms (1s, 2s, 4s, 8s, 16s)
- **Queue processing**: Scheduled based on earliest retry time
- **Graceful shutdown**: All pending webhooks attempted on SIGTERM
- **Error handling**: Comprehensive logging at each retry attempt

## Acceptance Criteria
- [x] Failed webhook deliveries are re-queued automatically
- [x] Max 5 retries with exponential backoff
- [x] Failed attempts logged at WARN level with webhook URL and attempt count
- [x] Queue drained on SIGTERM before process exits