### PR TITLE
feat(backend): add POST /api/meters/batch accepting array of {meter_id, owner} pairs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@stellar/stellar-sdk": "^12.0.0",
         "@types/cors": "^2.8.19",
-        "better-sqlite3": "^11.7.0",
+        "better-sqlite3": "^11.10.0",
         "connect-timeout": "^1.9.0",
         "cors": "^2.8.6",
         "dotenv": "^16.4.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",
     "@types/cors": "^2.8.19",
-    "better-sqlite3": "^11.7.0",
+    "better-sqlite3": "^11.10.0",
     "connect-timeout": "^1.9.0",
     "cors": "^2.8.6",
     "dotenv": "^16.4.5",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,9 @@ import { collaboratorRouter } from "./routes/collaborators.js";
 import { allowlistRouter } from "./routes/allowlist.js";
 import { statsRouter } from "./routes/stats.js";
 import { metricsRouter } from "./routes/metrics.js";
+import { providerRouter } from "./routes/provider.js";
+import { solarRouter } from "./routes/solar.js";
+
 import { startIoTBridge } from "./iot/bridge.js";
 import { startLimitWatcher } from "./iot/limitWatcher.js";
 import { logger } from "./lib/logger.js";

--- a/backend/src/middleware/cache.ts
+++ b/backend/src/middleware/cache.ts
@@ -26,3 +26,12 @@ export function invalidateCache(prefix: string) {
     if (key.startsWith(prefix)) store.delete(key);
   }
 }
+
+import crypto from "crypto";
+
+export function etagFor(data: unknown): string {
+  const str = typeof data === "string" ? data : JSON.stringify(data);
+  const hash = crypto.createHash("sha1").update(str).digest("base64");
+  return `W/"${hash}"`;
+}
+

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,10 +1,16 @@
-
 import { Request, Response, NextFunction } from 'express';
 import { logger } from '../lib/logger.js';
 import { randomUUID } from 'crypto';
+import { requestContext } from '../lib/requestContext.js';
 
-export default function requestLogger(req: Request, _res: Response, next: NextFunction) {
-  (req as any).reqId = randomUUID();
-  logger.info({ reqId: (req as any).reqId, method: req.method, path: req.path });
-  next();
+export default function requestLogger(req: Request, res: Response, next: NextFunction) {
+  const reqId = (req.headers['x-request-id'] as string) || (req as any).reqId || randomUUID();
+  (req as any).reqId = reqId;
+  res.setHeader('X-Request-ID', reqId);
+  
+  logger.info({ reqId, method: req.method, path: req.path });
+  
+  requestContext.run({ reqId }, () => {
+    next();
+  });
 }

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -4,12 +4,14 @@ import { StellarService, stellarService } from "../lib/stellar.js";
 import {
   getUsageHistory,
   persistAndSubmitUsageEvent,
+  initUsageEventStore,
 } from "../lib/usageEvents.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
 import { validateRequest, RegisterMeterSchema } from "../lib/validation.js";
 import { adminAuth } from "../lib/adminAuth.js";
 import { requireAdminKey } from "../middleware/adminAuth.js";
 import { cacheFor, invalidateCache, etagFor } from "../middleware/cache.js";
+import { getMqttClient } from "../iot/mqttClient.js";
 
 const balanceCache = new Map<string, { data: any; ts: number }>();
 const BALANCE_CACHE_TTL_MS = 5_000; // 5-second cache to reduce RPC load
@@ -101,6 +103,32 @@ export function createMeterRouter(stellar: StellarService) {
       });
 
       res.json({ expiring, count: expiring.length });
+    })
+  );
+
+  /** GET /api/meters/inactive — return meters where active=false with last_used timestamp */
+  meterRouter.get(
+    "/inactive",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const result = await stellar.query("get_all_meters", []);
+      const allMeters = (StellarSdk.scValToNative(result) as any[]) ?? [];
+
+      const inactiveMeters = allMeters.filter((m: any) => !m.active);
+
+      const dbInstance = initUsageEventStore();
+      const inactiveWithLastUsed = inactiveMeters.map((m: any) => {
+        const row = dbInstance
+          .prepare("SELECT MAX(received_at) as last_used FROM usage_events WHERE meter_id = ?")
+          .get(m.id) as { last_used: string | null } | undefined;
+        
+        return {
+          ...m,
+          last_used: row?.last_used ?? null,
+        };
+      });
+
+      res.json({ inactive: inactiveWithLastUsed, count: inactiveWithLastUsed.length });
     })
   );
 
@@ -266,6 +294,18 @@ export function createMeterRouter(stellar: StellarService) {
         StellarSdk.nativeToScVal(meterId, { type: "symbol" }),
         StellarSdk.nativeToScVal(false, { type: "bool" }),
       ]);
+      
+      try {
+        const mqttClient = getMqttClient();
+        mqttClient.publish(
+          `solargrid/meters/${meterId}/control`,
+          JSON.stringify({ cmd: 'OFF', timestamp: new Date().toISOString() }),
+          { qos: 1 }
+        );
+      } catch (err) {
+        logger.error("Failed to publish MQTT deactivation message", { meterId, err });
+      }
+
       res.json({ hash, meter_id: meterId, active: false });
     }),
   );

--- a/backend/src/routes/meters.ts
+++ b/backend/src/routes/meters.ts
@@ -10,7 +10,6 @@ import { validateRequest, RegisterMeterSchema } from "../lib/validation.js";
 import { adminAuth } from "../lib/adminAuth.js";
 import { requireAdminKey } from "../middleware/adminAuth.js";
 import { cacheFor, invalidateCache, etagFor } from "../middleware/cache.js";
-import { cacheFor, invalidateCache } from "../middleware/cache.js";
 
 const balanceCache = new Map<string, { data: any; ts: number }>();
 const BALANCE_CACHE_TTL_MS = 5_000; // 5-second cache to reduce RPC load
@@ -457,6 +456,58 @@ export function createMeterRouter(stellar: StellarService) {
     }),
   );
 
+  /** POST /api/meters/batch — batch register meters (admin only) */
+  meterRouter.post(
+    "/batch",
+    requireAdminKey,
+    asyncHandler(async (req, res) => {
+      const { meters } = req.body;
+      if (!meters || !Array.isArray(meters)) {
+        return res.status(400).json({ error: "meters array is required", code: "VALIDATION_ERROR" });
+      }
+      if (meters.length > 50) {
+        return res.status(400).json({ error: "At most 50 meters can be registered in a batch", code: "VALIDATION_ERROR" });
+      }
+
+      const STELLAR_ACCOUNT_REGEX = /^G[A-Z2-7]{55}$/;
+      const results: Array<{ meter_id: string; hash?: string; error?: string }> = [];
+
+      for (const item of meters) {
+        const meterId = item?.meter_id;
+        const owner = item?.owner;
+
+        if (!meterId || typeof meterId !== "string" || meterId.trim().length === 0) {
+          results.push({ meter_id: String(meterId ?? ""), error: "meter_id is required" });
+          continue;
+        }
+
+        const trimmedId = meterId.trim();
+        if (trimmedId.length > 12) {
+          results.push({ meter_id: trimmedId, error: "meter_id must be at most 12 characters" });
+          continue;
+        }
+
+        if (!owner || typeof owner !== "string" || !STELLAR_ACCOUNT_REGEX.test(owner)) {
+          results.push({ meter_id: trimmedId, error: "Invalid Stellar account address format" });
+          continue;
+        }
+
+        try {
+          const hash = await stellar.invoke("register_meter", [
+            StellarSdk.nativeToScVal(trimmedId, { type: "symbol" }),
+            StellarSdk.nativeToScVal(owner, { type: "address" }),
+          ]);
+          results.push({ meter_id: trimmedId, hash });
+        } catch (err: any) {
+          results.push({ meter_id: trimmedId, error: err.message ?? "Registration failed" });
+        }
+      }
+
+      res.json({ results });
+    }),
+  );
+
+
   /** POST /api/meters/:id/usage — IoT oracle reports usage */
   meterRouter.post("/:id/usage", requireAdminKey, async (req, res) => {
     const { units, cost } = req.body as { units: unknown; cost: unknown };
@@ -561,8 +612,6 @@ export function createMeterRouter(stellar: StellarService) {
     }),
   );
 
-  return meterRouter;
-}
   /** DELETE /api/meters/:id — admin deregisters a meter */
   meterRouter.delete(
     "/:id",

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { z } from "zod";
-import { server, CONTRACT_ID, NETWORK_PASSPHRASE, adminInvoke } from "../lib/stellar.js";
+import { server, CONTRACT_ID, NETWORK_PASSPHRASE, adminInvoke, stellarService } from "../lib/stellar.js";
 import { logger } from "../lib/logger.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
 

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -19,6 +19,13 @@ let metersByPlanCache: { data: object; expiresAt: number } | null = null;
 // Cache for meter counts grouped by plan (30s TTL)
 let meterPlanCache: { data: object; expiresAt: number } | null = null;
 
+export function __resetStatsCache() {
+  contractCache = null;
+  metricsCache = null;
+  metersByPlanCache = null;
+  meterPlanCache = null;
+}
+
 
 type MeterPlanBreakdown = {
   Daily: number;

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import * as crypto from "crypto";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { stellarService } from "../lib/stellar.js";
-import { registerWebhook } from "../lib/webhookRegistry.js";
+import { registerWebhook, getWebhookUrls } from "../lib/webhookRegistry.js";
 import { asyncHandler } from "../lib/asyncHandler.js";
 import { validateRequest } from "../lib/validation.js";
 import { logger } from "../lib/logger.js";
@@ -91,6 +91,22 @@ webhookRouter.post(
     return res.status(200).json({
       message: "Webhook registered successfully",
       webhook_url,
+    });
+  }),
+);
+
+/**
+ * GET /api/webhooks
+ *
+ * List all registered low-balance webhook URLs.
+ */
+webhookRouter.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const urls = Array.from(getWebhookUrls());
+    return res.status(200).json({
+      webhooks: urls,
+      count: urls.length,
     });
   }),
 );

--- a/backend/tests/meters-batch.test.ts
+++ b/backend/tests/meters-batch.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Request, Response } from "express";
+
+// Mock the stellar module before importing routes
+vi.mock("../src/lib/stellar", () => ({
+  stellarService: {
+    invoke: vi.fn(),
+    query: vi.fn(),
+    contractId: "C123",
+    server: {},
+    adminKeypair: {},
+    networkPassphrase: "test",
+  },
+}));
+
+import { createMeterRouter } from "../src/routes/meters";
+import { stellarService } from "../src/lib/stellar";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+describe("metersRouter - POST /api/meters/batch", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let jsonMock: any;
+  let statusMock: any;
+  let router: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    jsonMock = vi.fn().mockReturnValue({});
+    statusMock = vi.fn().mockReturnValue({ json: jsonMock });
+    
+    req = {
+      body: {},
+      headers: {
+        "x-admin-key": "test-admin-key",
+      },
+    };
+    res = {
+      json: jsonMock,
+      status: statusMock,
+    };
+
+    process.env.ADMIN_KEY = "test-admin-key";
+
+    router = createMeterRouter(stellarService);
+  });
+
+  it("should fail if meters array is missing or not an array", async () => {
+    req.body = {};
+    
+    const handler = router.stack.find(
+      (layer: any) => layer.route?.path === "/batch" && layer.route?.methods.post
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    if (!handler) {
+      throw new Error("Batch registration endpoint handler not found");
+    }
+
+    await handler(req, res);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({
+      error: "meters array is required",
+      code: "VALIDATION_ERROR",
+    });
+  });
+
+  it("should fail if meters array has more than 50 items", async () => {
+    req.body = {
+      meters: Array.from({ length: 51 }, (_, i) => ({
+        meter_id: `m${i}`,
+        owner: "GCFJQANBW7ZMPW73MFD4IJBCNWGVWCE5QEGFBJWCF5NJDEBXADZBMRMC",
+      })),
+    };
+    
+    const handler = router.stack.find(
+      (layer: any) => layer.route?.path === "/batch" && layer.route?.methods.post
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    await handler(req, res);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({
+      error: "At most 50 meters can be registered in a batch",
+      code: "VALIDATION_ERROR",
+    });
+  });
+
+  it("should register valid meters and return individual item results", async () => {
+    (stellarService.invoke as any).mockResolvedValue("mock-tx-hash");
+
+    req.body = {
+      meters: [
+        {
+          meter_id: "meter1",
+          owner: "GCFJQANBW7ZMPW73MFD4IJBCNWGVWCE5QEGFBJWCF5NJDEBXADZBMRMC",
+        },
+        {
+          meter_id: "meter2_too_long_id",
+          owner: "GCFJQANBW7ZMPW73MFD4IJBCNWGVWCE5QEGFBJWCF5NJDEBXADZBMRMC",
+        },
+        {
+          meter_id: "meter3",
+          owner: "invalid-address",
+        },
+      ],
+    };
+
+    const handler = router.stack.find(
+      (layer: any) => layer.route?.path === "/batch" && layer.route?.methods.post
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    await handler(req, res);
+    expect(stellarService.invoke).toHaveBeenCalledTimes(1); // Only meter1 is valid
+    const responseData = jsonMock.mock.calls[0][0];
+
+
+
+    expect(responseData.results).toHaveLength(3);
+    expect(responseData.results[0]).toEqual({
+      meter_id: "meter1",
+      hash: "mock-tx-hash",
+    });
+    expect(responseData.results[1]).toEqual({
+      meter_id: "meter2_too_long_id",
+      error: "meter_id must be at most 12 characters",
+    });
+    expect(responseData.results[2]).toEqual({
+      meter_id: "meter3",
+      error: "Invalid Stellar account address format",
+    });
+  });
+});

--- a/backend/tests/meters-deactivate.test.ts
+++ b/backend/tests/meters-deactivate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Request, Response } from "express";
+
+// Mock the stellar module before importing routes
+vi.mock("../src/lib/stellar", () => ({
+  stellarService: {
+    invoke: vi.fn(),
+    query: vi.fn(),
+    contractId: "C123",
+    server: {},
+    adminKeypair: {},
+    networkPassphrase: "test",
+  },
+}));
+
+// Mock the mqttClient module
+const mockPublish = vi.fn();
+vi.mock("../src/iot/mqttClient.js", () => ({
+  getMqttClient: () => ({
+    publish: mockPublish,
+  }),
+}));
+
+import { createMeterRouter } from "../src/routes/meters";
+import { stellarService } from "../src/lib/stellar";
+import { getMqttClient } from "../src/iot/mqttClient.js";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+describe("metersRouter - POST /api/meters/:id/deactivate", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let jsonMock: any;
+  let statusMock: any;
+  let router: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    jsonMock = vi.fn().mockReturnValue({});
+    statusMock = vi.fn().mockReturnValue({ json: jsonMock });
+    
+    req = {
+      params: {
+        id: "meter123",
+      },
+      headers: {
+        "x-admin-key": "test-admin-key",
+      },
+    };
+    res = {
+      json: jsonMock,
+      status: statusMock,
+    };
+
+    process.env.ADMIN_KEY = "test-admin-key";
+
+    router = createMeterRouter(stellarService);
+  });
+
+  it("should deactivate meter and publish MQTT OFF message", async () => {
+    (stellarService.query as any).mockResolvedValue(
+      StellarSdk.nativeToScVal({ active: true })
+    );
+
+    (stellarService.invoke as any).mockResolvedValue("mock-deactivate-tx");
+
+    const handler = router.stack.find(
+      (layer: any) => layer.route?.path === "/:id/deactivate" && layer.route?.methods.post
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    if (!handler) {
+      throw new Error("Deactivate endpoint handler not found");
+    }
+
+    // Call the handler
+    handler(req, res, () => {});
+
+    // Wait a short time to allow the async handler promises to resolve
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(stellarService.query).toHaveBeenCalledWith("get_meter", expect.any(Array));
+    expect(stellarService.invoke).toHaveBeenCalledWith("set_active", expect.any(Array));
+    
+    // Assert on the mock function returned by getMqttClient().publish
+    const client = getMqttClient();
+    expect(client.publish).toHaveBeenCalledWith(
+      "solargrid/meters/meter123/control",
+      expect.stringContaining('"cmd":"OFF"'),
+      { qos: 1 }
+    );
+
+    expect(jsonMock).toHaveBeenCalledWith({
+      hash: "mock-deactivate-tx",
+      meter_id: "meter123",
+      active: false,
+    });
+  });
+});

--- a/backend/tests/meters-inactive.test.ts
+++ b/backend/tests/meters-inactive.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Request, Response } from "express";
+
+// Mock the stellar module before importing routes
+vi.mock("../src/lib/stellar", () => ({
+  stellarService: {
+    invoke: vi.fn(),
+    query: vi.fn(),
+    contractId: "C123",
+    server: {},
+    adminKeypair: {},
+    networkPassphrase: "test",
+  },
+}));
+
+// Set in-memory db path before imports to avoid writing to real database file
+process.env.USAGE_EVENTS_DB_PATH = ":memory:";
+
+import { createMeterRouter } from "../src/routes/meters";
+import { stellarService } from "../src/lib/stellar";
+import { initUsageEventStore } from "../src/lib/usageEvents";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+describe("metersRouter - GET /api/meters/inactive", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let jsonMock: any;
+  let statusMock: any;
+  let router: any;
+  let db: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    jsonMock = vi.fn().mockReturnValue({});
+    statusMock = vi.fn().mockReturnValue({ json: jsonMock });
+    
+    req = {
+      query: {},
+      headers: {
+        "x-admin-key": "test-admin-key",
+      },
+    };
+    res = {
+      json: jsonMock,
+      status: statusMock,
+    };
+
+    process.env.ADMIN_KEY = "test-admin-key";
+
+    router = createMeterRouter(stellarService);
+    db = initUsageEventStore();
+    // Clear usage_events table for a clean test
+    db.exec("DELETE FROM usage_events");
+  });
+
+  it("should verify requireAdminKey middleware is registered", async () => {
+    const route = router.stack.find(
+      (layer: any) => layer.route?.path === "/inactive" && layer.route?.methods.get
+    )?.route;
+    
+    expect(route).toBeDefined();
+    const middlewareNames = route.stack.map((layer: any) => layer.name);
+    expect(middlewareNames).toContain("requireAdminKey");
+  });
+
+  it("should list inactive meters and map their last_used from DB", async () => {
+    const mockMeters = [
+      { id: "active-meter", owner: "user1", active: true },
+      { id: "inactive-meter-1", owner: "user2", active: false },
+      { id: "inactive-meter-2", owner: "user3", active: false },
+    ];
+    (stellarService.query as any).mockResolvedValue(
+      StellarSdk.nativeToScVal(mockMeters)
+    );
+
+    const nowStr1 = "2026-07-09T12:00:00.000Z";
+    const nowStr2 = "2026-07-09T13:00:00.000Z";
+    
+    db.prepare(
+      "INSERT INTO usage_events (meter_id, units, cost, received_at, status) VALUES (?, ?, ?, ?, ?)"
+    ).run("inactive-meter-1", 10, "100", nowStr1, "submitted");
+
+    db.prepare(
+      "INSERT INTO usage_events (meter_id, units, cost, received_at, status) VALUES (?, ?, ?, ?, ?)"
+    ).run("inactive-meter-1", 5, "50", nowStr2, "submitted");
+
+    const handler = router.stack.find(
+      (layer: any) => layer.route?.path === "/inactive" && layer.route?.methods.get
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    await handler(req, res);
+
+    expect(jsonMock).toHaveBeenCalledWith({
+      inactive: [
+        { id: "inactive-meter-1", owner: "user2", active: false, last_used: nowStr2 },
+        { id: "inactive-meter-2", owner: "user3", active: false, last_used: null },
+      ],
+      count: 2,
+    });
+  });
+});

--- a/backend/tests/payments-history.test.ts
+++ b/backend/tests/payments-history.test.ts
@@ -9,7 +9,7 @@ vi.mock("../src/lib/stellar", () => ({
     timestampToLedger: vi.fn(),
   },
   CONTRACT_ID: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-  NETWORK_PASSPHRASE: StellarSdk.Networks.TESTNET,
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
   server: {
     getEvents: vi.fn(),
   },

--- a/backend/tests/request-id.test.ts
+++ b/backend/tests/request-id.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Request, Response } from "express";
+import requestLogger from "../src/middleware/requestLogger";
+import { getReqId } from "../src/lib/requestContext";
+
+describe("requestLogger middleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let nextMock: any;
+  let headersMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    headersMock = {};
+    req = {
+      headers: {},
+      method: "GET",
+      path: "/test",
+    };
+    res = {
+      setHeader: vi.fn((name, value) => {
+        headersMock[name] = value;
+      }) as any,
+    };
+    nextMock = vi.fn();
+  });
+
+  it("should generate a randomUUID if X-Request-ID header is missing", () => {
+    requestLogger(req as Request, res as Response, () => {
+      expect((req as any).reqId).toBeDefined();
+      expect(headersMock["X-Request-ID"]).toBe((req as any).reqId);
+      expect(getReqId()).toBe((req as any).reqId);
+      nextMock();
+    });
+
+    expect(nextMock).toHaveBeenCalled();
+  });
+
+  it("should reuse X-Request-ID header if present", () => {
+    const existingId = "existing-uuid-12345";
+    req.headers!["x-request-id"] = existingId;
+
+    requestLogger(req as Request, res as Response, () => {
+      expect((req as any).reqId).toBe(existingId);
+      expect(headersMock["X-Request-ID"]).toBe(existingId);
+      expect(getReqId()).toBe(existingId);
+      nextMock();
+    });
+
+    expect(nextMock).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/stats.test.ts
+++ b/backend/tests/stats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Request, Response } from "express";
-import { statsRouter } from "../src/routes/stats";
+import { statsRouter, __resetStatsCache } from "../src/routes/stats";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { stellarService } from "../src/lib/stellar";
 
@@ -18,6 +18,8 @@ describe("statsRouter - GET /api/stats", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetStatsCache();
+
     
     jsonMock = vi.fn().mockReturnValue({});
     statusMock = vi.fn().mockReturnValue({ json: jsonMock });

--- a/backend/tests/webhooks.test.ts
+++ b/backend/tests/webhooks.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Request, Response } from "express";
+
+// Mock the stellar module before importing routes to prevent Keypair error
+vi.mock("../src/lib/stellar", () => ({
+  stellarService: {
+    invoke: vi.fn(),
+    query: vi.fn(),
+    contractId: "C123",
+    server: {},
+    adminKeypair: {},
+    networkPassphrase: "test",
+  },
+}));
+
+import { webhookRouter } from "../src/routes/webhooks";
+import { registerWebhook, getWebhookUrls } from "../src/lib/webhookRegistry";
+
+describe("webhookRouter - GET /api/webhooks", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let jsonMock: any;
+  let statusMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    jsonMock = vi.fn().mockReturnValue({});
+    statusMock = vi.fn().mockReturnValue({ json: jsonMock });
+    
+    req = {};
+    res = {
+      json: jsonMock,
+      status: statusMock,
+    };
+    
+    const urls = getWebhookUrls() as Set<string>;
+    urls.clear();
+  });
+
+  it("should return empty list when no webhooks are registered", async () => {
+    const handler = webhookRouter.stack.find(
+      (layer: any) => layer.route?.path === "/" && layer.route?.methods.get
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    if (!handler) {
+      throw new Error("GET / endpoint handler not found");
+    }
+
+    await handler(req, res);
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({
+      webhooks: [],
+      count: 0,
+    });
+  });
+
+  it("should return registered webhooks", async () => {
+    registerWebhook("https://example.com/webhook1");
+    registerWebhook("https://example.com/webhook2");
+
+    const handler = webhookRouter.stack.find(
+      (layer: any) => layer.route?.path === "/" && layer.route?.methods.get
+    )?.route?.stack.slice(-1)[0]?.handle;
+
+    await handler(req, res);
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({
+      webhooks: ["https://example.com/webhook1", "https://example.com/webhook2"],
+      count: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements a consolidated set of backend features and fixes, resolving multiple open issues in the Stellar Wave Program:

1. **Batch Meter Registration**: Added `POST /api/meters/batch` to register multiple meters at once (Closes #445).
2. **Inactive Meters Audit**: Added `GET /api/meters/inactive` listing dormant meters with their last active timestamp queried from the local SQLite database (Closes #446).
3. **Webhooks Listing**: Added `GET /api/webhooks` endpoint returning all registered low-balance webhook URLs (Closes #444).
4. **X-Request-ID Propagation**: Integrated `requestContext.ts` with `requestLogger` middleware to run the request lifecycle under AsyncLocalStorage and set/propagate the `X-Request-ID` header on all responses (Closes #443).
5. **Deactivation MQTT Signal**: Emits an immediate MQTT `OFF` control message when a meter is deactivated via `POST /api/meters/:id/deactivate` to bypass Soroban contract polling latency (Closes #442).

## Changes

- **Backend API Routes**: Implemented the routes in `backend/src/routes/meters.ts` and `backend/src/routes/webhooks.ts`.
- **Request Context Middleware**: Updated `backend/src/middleware/requestLogger.ts`.
- **Unit Tests**: Created focused Vitest suites for the new endpoints:
  - `backend/tests/meters-inactive.test.ts`
  - `backend/tests/webhooks.test.ts`
  - `backend/tests/request-id.test.ts`
  - `backend/tests/meters-deactivate.test.ts`
- **Node Compatibility**: Fixed the local better-sqlite3 native binary version mismatch to ensure clean test suite execution.

All tests are passing successfully locally. Ready for review!